### PR TITLE
Clean test stdout

### DIFF
--- a/logger_test.go
+++ b/logger_test.go
@@ -2,8 +2,8 @@ package qb
 
 import (
 	"github.com/stretchr/testify/assert"
+	"io/ioutil"
 	"log"
-	"os"
 	"testing"
 )
 
@@ -16,7 +16,7 @@ func TestLogger(t *testing.T) {
 	db.Metadata().AddTable(actors)
 	db.CreateAll()
 	defer db.DropAll()
-	db.Engine().SetLogger(DefaultLogger{LQuery | LBindings, log.New(os.Stdout, "", log.LstdFlags)})
+	db.Engine().SetLogger(DefaultLogger{LQuery | LBindings, log.New(ioutil.Discard, "", log.LstdFlags)})
 	db.Engine().Logger().SetLogFlags(LQuery)
 
 	_, err = db.Engine().Exec(actors.Insert().Values(map[string]interface{}{"id": 5}))

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -1,7 +1,6 @@
 package qb
 
 import (
-	"fmt"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -40,7 +39,6 @@ func TestMapper(t *testing.T) {
 	assert.Nil(t, err)
 
 	ddl := userTable.Create(dialect)
-	fmt.Println(ddl, "\n")
 
 	assert.Contains(t, ddl, "CREATE TABLE user (")
 	assert.Contains(t, ddl, "id VARCHAR(255)")
@@ -82,8 +80,6 @@ func TestMapperSqliteAutoIncrement(t *testing.T) {
 	assert.Contains(t, ddl, "CREATE TABLE user (")
 	assert.Contains(t, ddl, "id BIGINT")
 	assert.Contains(t, ddl, ")")
-
-	fmt.Println(ddl, "\n")
 }
 
 func TestMapperWithDBTag(t *testing.T) {
@@ -108,8 +104,6 @@ func TestMapperWithDBTag(t *testing.T) {
 		"_id":   "cba0667d-8c76-4999-9a55-84ffe572fb23",
 		"email": "aras@slicebit.com",
 	})
-
-	fmt.Println(ddl, "\n")
 }
 
 func TestMapperPostgresAutoIncrement(t *testing.T) {
@@ -137,7 +131,6 @@ func TestMapperError(t *testing.T) {
 
 	userErrTable, err := mapper.ToTable(UserErr{})
 
-	fmt.Println(err)
 	assert.NotNil(t, err)
 	assert.Zero(t, userErrTable)
 }

--- a/postgres_test.go
+++ b/postgres_test.go
@@ -2,7 +2,6 @@ package qb
 
 import (
 	"database/sql"
-	"fmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"os"
@@ -82,7 +81,6 @@ func (suite *PostgresTestSuite) TestPostgres() {
 
 	_, err = suite.db.Engine().Exec(statement)
 	assert.NotNil(suite.T(), err)
-	fmt.Println("Duplicate error; ", err)
 
 	statement = Insert(suite.db.T("user")).
 		Values(map[string]interface{}{

--- a/table_test.go
+++ b/table_test.go
@@ -1,7 +1,6 @@
 package qb
 
 import (
-	"fmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"testing"
@@ -16,7 +15,6 @@ func (suite *TableTestSuite) TestTableSimpleCreateDrop() {
 	usersTable := Table("users", Column("id", Varchar().Size(40)))
 
 	ddl := usersTable.Create(dialect)
-	fmt.Println(ddl, "\n")
 	assert.Equal(suite.T(), ddl, "CREATE TABLE users (\n\tid VARCHAR(40)\n);")
 
 	statement := usersTable.Build(dialect)
@@ -41,7 +39,6 @@ func (suite *TableTestSuite) TestTablePrimaryForeignKey() {
 	)
 
 	ddl := usersTable.Create(NewDialect("mysql"))
-	fmt.Println(ddl, "\n")
 	assert.Contains(suite.T(), ddl, "CREATE TABLE users (")
 	assert.Contains(suite.T(), ddl, "auth_token VARCHAR(40)")
 	assert.Contains(suite.T(), ddl, "role_id VARCHAR(40)")
@@ -63,7 +60,6 @@ func (suite *TableTestSuite) TestTableUniqueCompositeUnique() {
 	)
 
 	ddl := usersTable.Create(NewDialect("mysql"))
-	fmt.Println(ddl, "\n")
 	assert.Contains(suite.T(), ddl, "CREATE TABLE users (")
 	assert.Contains(suite.T(), ddl, "id VARCHAR(40)")
 	assert.Contains(suite.T(), ddl, "email VARCHAR(40) UNIQUE")
@@ -82,7 +78,6 @@ func (suite *TableTestSuite) TestTableIndex() {
 		Index("users", "id", "email"),
 	)
 	ddl := usersTable.Create(NewDialect("postgres"))
-	fmt.Println(ddl, "\n")
 	assert.Contains(suite.T(), ddl, "CREATE TABLE users (")
 	assert.Contains(suite.T(), ddl, "id VARCHAR(40)")
 	assert.Contains(suite.T(), ddl, "email VARCHAR(40) UNIQUE")
@@ -98,7 +93,6 @@ func (suite *TableTestSuite) TestTableIndex() {
 func (suite *TableTestSuite) TestTableIndexChain() {
 	usersTable := Table("users", Column("id", Varchar().Size(40))).Index("id")
 	ddl := usersTable.Create(NewDialect("mysql"))
-	fmt.Println(ddl, "\n")
 	assert.Equal(suite.T(), ddl, "CREATE TABLE users (\n\tid VARCHAR(40)\n);\nCREATE INDEX i_id ON users(id);")
 }
 


### PR DESCRIPTION
During tests the stdout is polluted with many debug prints.
It makes it difficult to debug failing tests (lots of useless scrolling involved).

This PR cleans it up.