### PR TITLE
[tests] Switch assert.Equal args

### DIFF
--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -7,9 +7,9 @@ import (
 
 func TestAggregates(t *testing.T) {
 	col := Column("id", Varchar().Size(36))
-	assert.Equal(t, Avg(col), Aggregate("AVG", col))
-	assert.Equal(t, Count(col), Aggregate("COUNT", col))
-	assert.Equal(t, Sum(col), Aggregate("SUM", col))
-	assert.Equal(t, Min(col), Aggregate("MIN", col))
-	assert.Equal(t, Max(col), Aggregate("MAX", col))
+	assert.Equal(t, Aggregate("AVG", col), Avg(col))
+	assert.Equal(t, Aggregate("COUNT", col), Count(col))
+	assert.Equal(t, Aggregate("SUM", col), Sum(col))
+	assert.Equal(t, Aggregate("MIN", col), Min(col))
+	assert.Equal(t, Aggregate("MAX", col), Max(col))
 }

--- a/column_test.go
+++ b/column_test.go
@@ -16,27 +16,27 @@ func TestColumn(t *testing.T) {
 	postgres.SetEscaping(true)
 
 	col := Column("id", Varchar().Size(40))
-	assert.Equal(t, col.Name, "id")
-	assert.Equal(t, col.Type, Varchar().Size(40))
+	assert.Equal(t, "id", col.Name)
+	assert.Equal(t, Varchar().Size(40), col.Type)
 
-	assert.Equal(t, col.String(sqlite), "id VARCHAR(40)")
-	assert.Equal(t, col.String(mysql), "`id` VARCHAR(40)")
-	assert.Equal(t, col.String(postgres), "\"id\" VARCHAR(40)")
+	assert.Equal(t, "id VARCHAR(40)", col.String(sqlite))
+	assert.Equal(t, "`id` VARCHAR(40)", col.String(mysql))
+	assert.Equal(t, "\"id\" VARCHAR(40)", col.String(postgres))
 
 	col = Column("id", Int()).PrimaryKey().AutoIncrement()
 
-	assert.Equal(t, col.String(sqlite), "id INTEGER PRIMARY KEY")
-	assert.Equal(t, col.String(mysql), "`id` INT PRIMARY KEY AUTO_INCREMENT")
-	assert.Equal(t, col.String(postgres), "\"id\" SERIAL PRIMARY KEY")
+	assert.Equal(t, "id INTEGER PRIMARY KEY", col.String(sqlite))
+	assert.Equal(t, "`id` INT PRIMARY KEY AUTO_INCREMENT", col.String(mysql))
+	assert.Equal(t, "\"id\" SERIAL PRIMARY KEY", col.String(postgres))
 
 	var sql string
 
 	sql, _ = col.Build(sqlite)
-	assert.Equal(t, sql, "id")
+	assert.Equal(t, "id", sql)
 
 	sql, _ = col.Build(mysql)
-	assert.Equal(t, sql, "`id`")
+	assert.Equal(t, "`id`", sql)
 
 	sql, _ = col.Build(postgres)
-	assert.Equal(t, sql, "\"id\"")
+	assert.Equal(t, "\"id\"", sql)
 }

--- a/combiner_test.go
+++ b/combiner_test.go
@@ -25,31 +25,31 @@ func TestCombiners(t *testing.T) {
 	var bindings []interface{}
 	sql, bindings = and.Build(sqlite)
 
-	assert.Equal(t, sql, "(email = ? AND id != ?)")
-	assert.Equal(t, bindings, []interface{}{"al@pacino.com", 1})
+	assert.Equal(t, "(email = ? AND id != ?)", sql)
+	assert.Equal(t, []interface{}{"al@pacino.com", 1}, bindings)
 
 	sql, bindings = and.Build(mysql)
 
-	assert.Equal(t, sql, "(`email` = ? AND `id` != ?)")
-	assert.Equal(t, bindings, []interface{}{"al@pacino.com", 1})
+	assert.Equal(t, "(`email` = ? AND `id` != ?)", sql)
+	assert.Equal(t, []interface{}{"al@pacino.com", 1}, bindings)
 
 	sql, bindings = and.Build(postgres)
 
-	assert.Equal(t, sql, "(\"email\" = $1 AND \"id\" != $2)")
-	assert.Equal(t, bindings, []interface{}{"al@pacino.com", 1})
+	assert.Equal(t, "(\"email\" = $1 AND \"id\" != $2)", sql)
+	assert.Equal(t, []interface{}{"al@pacino.com", 1}, bindings)
 
 	sql, bindings = or.Build(sqlite)
 
-	assert.Equal(t, sql, "(email = ? OR id != ?)")
-	assert.Equal(t, bindings, []interface{}{"al@pacino.com", 1})
+	assert.Equal(t, "(email = ? OR id != ?)", sql)
+	assert.Equal(t, []interface{}{"al@pacino.com", 1}, bindings)
 
 	sql, bindings = or.Build(mysql)
 
-	assert.Equal(t, sql, "(`email` = ? OR `id` != ?)")
-	assert.Equal(t, bindings, []interface{}{"al@pacino.com", 1})
+	assert.Equal(t, "(`email` = ? OR `id` != ?)", sql)
+	assert.Equal(t, []interface{}{"al@pacino.com", 1}, bindings)
 
 	sql, bindings = or.Build(postgres)
 
-	assert.Equal(t, sql, "(\"email\" = $3 OR \"id\" != $4)")
-	assert.Equal(t, bindings, []interface{}{"al@pacino.com", 1})
+	assert.Equal(t, "(\"email\" = $3 OR \"id\" != $4)", sql)
+	assert.Equal(t, []interface{}{"al@pacino.com", 1}, bindings)
 }

--- a/conditional_test.go
+++ b/conditional_test.go
@@ -24,126 +24,126 @@ func TestConditionals(t *testing.T) {
 	like := Like(country, "%land%")
 
 	sql, _ = like.Build(sqlite)
-	assert.Equal(t, sql, "country LIKE '%land%'")
+	assert.Equal(t, "country LIKE '%land%'", sql)
 
 	sql, _ = like.Build(mysql)
-	assert.Equal(t, sql, "`country` LIKE '%land%'")
+	assert.Equal(t, "`country` LIKE '%land%'", sql)
 
 	sql, _ = like.Build(postgres)
-	assert.Equal(t, sql, "\"country\" LIKE '%land%'")
+	assert.Equal(t, "\"country\" LIKE '%land%'", sql)
 
 	notIn := NotIn(country, "USA", "England", "Sweden")
 
 	sql, bindings = notIn.Build(sqlite)
-	assert.Equal(t, sql, "country NOT IN (?, ?, ?)")
-	assert.Equal(t, bindings, []interface{}{"USA", "England", "Sweden"})
+	assert.Equal(t, "country NOT IN (?, ?, ?)", sql)
+	assert.Equal(t, []interface{}{"USA", "England", "Sweden"}, bindings)
 
 	sql, bindings = notIn.Build(mysql)
-	assert.Equal(t, sql, "`country` NOT IN (?, ?, ?)")
-	assert.Equal(t, bindings, []interface{}{"USA", "England", "Sweden"})
+	assert.Equal(t, "`country` NOT IN (?, ?, ?)", sql)
+	assert.Equal(t, []interface{}{"USA", "England", "Sweden"}, bindings)
 
 	sql, bindings = notIn.Build(postgres)
-	assert.Equal(t, sql, "\"country\" NOT IN ($1, $2, $3)")
-	assert.Equal(t, bindings, []interface{}{"USA", "England", "Sweden"})
+	assert.Equal(t, "\"country\" NOT IN ($1, $2, $3)", sql)
+	assert.Equal(t, []interface{}{"USA", "England", "Sweden"}, bindings)
 
 	in := In(country, "USA", "England", "Sweden")
 
 	sql, bindings = in.Build(sqlite)
-	assert.Equal(t, sql, "country IN (?, ?, ?)")
-	assert.Equal(t, bindings, []interface{}{"USA", "England", "Sweden"})
+	assert.Equal(t, "country IN (?, ?, ?)", sql)
+	assert.Equal(t, []interface{}{"USA", "England", "Sweden"}, bindings)
 
 	sql, bindings = in.Build(mysql)
-	assert.Equal(t, sql, "`country` IN (?, ?, ?)")
-	assert.Equal(t, bindings, []interface{}{"USA", "England", "Sweden"})
+	assert.Equal(t, "`country` IN (?, ?, ?)", sql)
+	assert.Equal(t, []interface{}{"USA", "England", "Sweden"}, bindings)
 
 	sql, bindings = in.Build(postgres)
-	assert.Equal(t, sql, "\"country\" IN ($4, $5, $6)")
-	assert.Equal(t, bindings, []interface{}{"USA", "England", "Sweden"})
+	assert.Equal(t, "\"country\" IN ($4, $5, $6)", sql)
+	assert.Equal(t, []interface{}{"USA", "England", "Sweden"}, bindings)
 
 	notEq := NotEq(country, "USA")
 
 	sql, bindings = notEq.Build(sqlite)
-	assert.Equal(t, sql, "country != ?")
-	assert.Equal(t, bindings, []interface{}{"USA"})
+	assert.Equal(t, "country != ?", sql)
+	assert.Equal(t, []interface{}{"USA"}, bindings)
 
 	sql, bindings = notEq.Build(mysql)
-	assert.Equal(t, sql, "`country` != ?")
-	assert.Equal(t, bindings, []interface{}{"USA"})
+	assert.Equal(t, "`country` != ?", sql)
+	assert.Equal(t, []interface{}{"USA"}, bindings)
 
 	sql, bindings = notEq.Build(postgres)
-	assert.Equal(t, sql, "\"country\" != $7")
-	assert.Equal(t, bindings, []interface{}{"USA"})
+	assert.Equal(t, "\"country\" != $7", sql)
+	assert.Equal(t, []interface{}{"USA"}, bindings)
 
 	eq := Eq(country, "Turkey")
 
 	sql, bindings = eq.Build(sqlite)
-	assert.Equal(t, sql, "country = ?")
-	assert.Equal(t, bindings, []interface{}{"Turkey"})
+	assert.Equal(t, "country = ?", sql)
+	assert.Equal(t, []interface{}{"Turkey"}, bindings)
 
 	sql, bindings = eq.Build(mysql)
-	assert.Equal(t, sql, "`country` = ?")
-	assert.Equal(t, bindings, []interface{}{"Turkey"})
+	assert.Equal(t, "`country` = ?", sql)
+	assert.Equal(t, []interface{}{"Turkey"}, bindings)
 
 	sql, bindings = eq.Build(postgres)
-	assert.Equal(t, sql, "\"country\" = $8")
-	assert.Equal(t, bindings, []interface{}{"Turkey"})
+	assert.Equal(t, "\"country\" = $8", sql)
+	assert.Equal(t, []interface{}{"Turkey"}, bindings)
 
 	score := Column("score", BigInt().NotNull())
 
 	gt := Gt(score, 1500)
 
 	sql, bindings = gt.Build(sqlite)
-	assert.Equal(t, sql, "score > ?")
-	assert.Equal(t, bindings, []interface{}{1500})
+	assert.Equal(t, "score > ?", sql)
+	assert.Equal(t, []interface{}{1500}, bindings)
 
 	sql, bindings = gt.Build(mysql)
-	assert.Equal(t, sql, "`score` > ?")
-	assert.Equal(t, bindings, []interface{}{1500})
+	assert.Equal(t, "`score` > ?", sql)
+	assert.Equal(t, []interface{}{1500}, bindings)
 
 	sql, bindings = gt.Build(postgres)
-	assert.Equal(t, sql, "\"score\" > $9")
-	assert.Equal(t, bindings, []interface{}{1500})
+	assert.Equal(t, "\"score\" > $9", sql)
+	assert.Equal(t, []interface{}{1500}, bindings)
 
 	st := St(score, 1500)
 
 	sql, bindings = st.Build(sqlite)
-	assert.Equal(t, sql, "score < ?")
-	assert.Equal(t, bindings, []interface{}{1500})
+	assert.Equal(t, "score < ?", sql)
+	assert.Equal(t, []interface{}{1500}, bindings)
 
 	sql, bindings = st.Build(mysql)
-	assert.Equal(t, sql, "`score` < ?")
-	assert.Equal(t, bindings, []interface{}{1500})
+	assert.Equal(t, "`score` < ?", sql)
+	assert.Equal(t, []interface{}{1500}, bindings)
 
 	sql, bindings = st.Build(postgres)
-	assert.Equal(t, sql, "\"score\" < $10")
-	assert.Equal(t, bindings, []interface{}{1500})
+	assert.Equal(t, "\"score\" < $10", sql)
+	assert.Equal(t, []interface{}{1500}, bindings)
 
 	gte := Gte(score, 1500)
 
 	sql, bindings = gte.Build(sqlite)
-	assert.Equal(t, sql, "score >= ?")
-	assert.Equal(t, bindings, []interface{}{1500})
+	assert.Equal(t, "score >= ?", sql)
+	assert.Equal(t, []interface{}{1500}, bindings)
 
 	sql, bindings = gte.Build(mysql)
-	assert.Equal(t, sql, "`score` >= ?")
-	assert.Equal(t, bindings, []interface{}{1500})
+	assert.Equal(t, "`score` >= ?", sql)
+	assert.Equal(t, []interface{}{1500}, bindings)
 
 	sql, bindings = gte.Build(postgres)
-	assert.Equal(t, sql, "\"score\" >= $11")
-	assert.Equal(t, bindings, []interface{}{1500})
+	assert.Equal(t, "\"score\" >= $11", sql)
+	assert.Equal(t, []interface{}{1500}, bindings)
 
 	ste := Ste(score, 1500)
 
 	sql, bindings = ste.Build(sqlite)
-	assert.Equal(t, sql, "score <= ?")
-	assert.Equal(t, bindings, []interface{}{1500})
+	assert.Equal(t, "score <= ?", sql)
+	assert.Equal(t, []interface{}{1500}, bindings)
 
 	sql, bindings = ste.Build(mysql)
-	assert.Equal(t, sql, "`score` <= ?")
-	assert.Equal(t, bindings, []interface{}{1500})
+	assert.Equal(t, "`score` <= ?", sql)
+	assert.Equal(t, []interface{}{1500}, bindings)
 
 	sql, bindings = ste.Build(postgres)
-	assert.Equal(t, sql, "\"score\" <= $12")
-	assert.Equal(t, bindings, []interface{}{1500})
+	assert.Equal(t, "\"score\" <= $12", sql)
+	assert.Equal(t, []interface{}{1500}, bindings)
 
 }

--- a/constraint_test.go
+++ b/constraint_test.go
@@ -7,12 +7,12 @@ import (
 
 func TestConstraints(t *testing.T) {
 
-	assert.Equal(t, Null(), Constraint("NULL"))
-	assert.Equal(t, NotNull(), Constraint("NOT NULL"))
-	assert.Equal(t, Default(5), Constraint("DEFAULT '5'"))
-	assert.Equal(t, Unique(), Constraint("UNIQUE"))
-	assert.Equal(t, Constraint("CHECK id > 5"), ConstraintElem{"CHECK id > 5"})
-	assert.Equal(t, NotNull().String(), "NOT NULL")
+	assert.Equal(t, Constraint("NULL"), Null())
+	assert.Equal(t, Constraint("NOT NULL"), NotNull())
+	assert.Equal(t, Constraint("DEFAULT '5'"), Default(5))
+	assert.Equal(t, Constraint("UNIQUE"), Unique())
+	assert.Equal(t, ConstraintElem{"CHECK id > 5"}, Constraint("CHECK id > 5"))
+	assert.Equal(t, "NOT NULL", NotNull().String())
 
 	sqlite := NewDialect("sqlite3")
 	sqlite.SetEscaping(true)
@@ -23,16 +23,16 @@ func TestConstraints(t *testing.T) {
 	postgres := NewDialect("postgres")
 	postgres.SetEscaping(true)
 
-	assert.Equal(t, PrimaryKey("id").String(sqlite), "PRIMARY KEY(id)")
-	assert.Equal(t, PrimaryKey("id", "email").String(mysql), "PRIMARY KEY(`id`, `email`)")
-	assert.Equal(t, PrimaryKey("id", "email").String(postgres), "PRIMARY KEY(\"id\", \"email\")")
+	assert.Equal(t, "PRIMARY KEY(id)", PrimaryKey("id").String(sqlite))
+	assert.Equal(t, "PRIMARY KEY(`id`, `email`)", PrimaryKey("id", "email").String(mysql))
+	assert.Equal(t, "PRIMARY KEY(\"id\", \"email\")", PrimaryKey("id", "email").String(postgres))
 
 	assert.Contains(t, ForeignKey().Ref("user_id", "users", "id").String(sqlite), "FOREIGN KEY(user_id) REFERENCES users(id)")
 	assert.Contains(t, ForeignKey().Ref("user_id", "users", "id").String(mysql), "FOREIGN KEY(`user_id`) REFERENCES `users`(`id`)")
 	assert.Contains(t, ForeignKey().Ref("user_id", "users", "id").String(postgres), "FOREIGN KEY(\"user_id\") REFERENCES \"users\"(\"id\")")
 	assert.Contains(t, ForeignKey().Ref("user_id", "users", "id").Ref("user_email", "users", "email").String(sqlite), "FOREIGN KEY(user_id, user_email) REFERENCES users(id, email)")
 
-	assert.Equal(t, UniqueKey("id", "email").String(sqlite), "CONSTRAINT u_id_email UNIQUE(id, email)")
-	assert.Equal(t, UniqueKey("id", "email").String(mysql), "CONSTRAINT u_id_email UNIQUE(`id`, `email`)")
-	assert.Equal(t, UniqueKey("id", "email").String(postgres), "CONSTRAINT u_id_email UNIQUE(\"id\", \"email\")")
+	assert.Equal(t, "CONSTRAINT u_id_email UNIQUE(id, email)", UniqueKey("id", "email").String(sqlite))
+	assert.Equal(t, "CONSTRAINT u_id_email UNIQUE(`id`, `email`)", UniqueKey("id", "email").String(mysql))
+	assert.Equal(t, "CONSTRAINT u_id_email UNIQUE(\"id\", \"email\")", UniqueKey("id", "email").String(postgres))
 }

--- a/delete_test.go
+++ b/delete_test.go
@@ -27,24 +27,24 @@ func TestDelete(t *testing.T) {
 		Where(Eq(users.C("id"), 5)).
 		Build(sqlite)
 
-	assert.Equal(t, statement.SQL(), "DELETE FROM users\nWHERE users.id = ?;")
-	assert.Equal(t, statement.Bindings(), []interface{}{5})
+	assert.Equal(t, "DELETE FROM users\nWHERE users.id = ?;", statement.SQL())
+	assert.Equal(t, []interface{}{5}, statement.Bindings())
 
 	statement = Delete(users).
 		Where(Eq(users.C("id"), 5)).
 		Build(mysql)
 
-	assert.Equal(t, statement.SQL(), "DELETE FROM `users`\nWHERE `users`.`id` = ?;")
-	assert.Equal(t, statement.Bindings(), []interface{}{5})
+	assert.Equal(t, "DELETE FROM `users`\nWHERE `users`.`id` = ?;", statement.SQL())
+	assert.Equal(t, []interface{}{5}, statement.Bindings())
 
 	statement = Delete(users).
 		Where(Eq(users.C("id"), 5)).
 		Returning(users.C("id")).
 		Build(postgres)
 
-	assert.Equal(t, statement.SQL(), "DELETE FROM \"users\"\nWHERE \"users\".\"id\" = $1\nRETURNING \"id\";")
-	assert.Equal(t, statement.Bindings(), []interface{}{5})
+	assert.Equal(t, "DELETE FROM \"users\"\nWHERE \"users\".\"id\" = $1\nRETURNING \"id\";", statement.SQL())
+	assert.Equal(t, []interface{}{5}, statement.Bindings())
 
 	statement = Delete(users).Build(sqlite)
-	assert.Equal(t, statement.SQL(), "DELETE FROM users;")
+	assert.Equal(t, "DELETE FROM users;", statement.SQL())
 }

--- a/dialect_test.go
+++ b/dialect_test.go
@@ -22,81 +22,75 @@ func (suite *DialectTestSuite) SetupTest() {
 }
 
 func (suite *DialectTestSuite) TestDefaultDialect() {
-	assert.Equal(suite.T(), suite.def.SupportsUnsigned(), false)
-	assert.Equal(suite.T(), suite.def.Escape("test"), "test")
-	assert.Equal(suite.T(), suite.def.Escaping(), false)
+	assert.Equal(suite.T(), false, suite.def.SupportsUnsigned())
+	assert.Equal(suite.T(), "test", suite.def.Escape("test"))
+	assert.Equal(suite.T(), false, suite.def.Escaping())
 	suite.def.SetEscaping(true)
-	assert.Equal(suite.T(), suite.def.Escaping(), true)
-	assert.Equal(suite.T(), suite.def.Escape("test"), "`test`")
-	assert.Equal(suite.T(), suite.def.EscapeAll([]string{"test"}), []string{"`test`"})
-	assert.Equal(suite.T(), suite.def.Placeholder(), "?")
-	assert.Equal(suite.T(), suite.def.Placeholders(5, 10), []string{"?", "?"})
-	assert.Equal(suite.T(), suite.def.Driver(), "")
+	assert.Equal(suite.T(), true, suite.def.Escaping())
+	assert.Equal(suite.T(), "`test`", suite.def.Escape("test"))
+	assert.Equal(suite.T(), []string{"`test`"}, suite.def.EscapeAll([]string{"test"}))
+	assert.Equal(suite.T(), "?", suite.def.Placeholder())
+	assert.Equal(suite.T(), []string{"?", "?"}, suite.def.Placeholders(5, 10))
+	assert.Equal(suite.T(), "", suite.def.Driver())
 
 	autoincCol := Column("id", Int()).PrimaryKey().AutoIncrement()
 	assert.Equal(suite.T(),
-		suite.def.AutoIncrement(&autoincCol),
-		"INT PRIMARY KEY AUTO INCREMENT")
+		"INT PRIMARY KEY AUTO INCREMENT",
+		suite.def.AutoIncrement(&autoincCol))
 
 	suite.def.Reset() // does nothing
 }
 
 func (suite *DialectTestSuite) TestMysqlDialect() {
-	assert.Equal(suite.T(), suite.mysql.SupportsUnsigned(), true)
-	assert.Equal(suite.T(), suite.mysql.Escape("test"), "test")
-	assert.Equal(suite.T(), suite.mysql.Escaping(), false)
+	assert.Equal(suite.T(), true, suite.mysql.SupportsUnsigned())
+	assert.Equal(suite.T(), "test", suite.mysql.Escape("test"))
+	assert.Equal(suite.T(), false, suite.mysql.Escaping())
 	suite.mysql.SetEscaping(true)
-	assert.Equal(suite.T(), suite.mysql.Escaping(), true)
-	assert.Equal(suite.T(), suite.mysql.Escape("test"), "`test`")
-	assert.Equal(suite.T(), suite.mysql.EscapeAll([]string{"test"}), []string{"`test`"})
-	assert.Equal(suite.T(), suite.mysql.Placeholder(), "?")
-	assert.Equal(suite.T(), suite.mysql.Placeholders(5, 10), []string{"?", "?"})
-	assert.Equal(suite.T(), suite.mysql.Driver(), "mysql")
+	assert.Equal(suite.T(), true, suite.mysql.Escaping())
+	assert.Equal(suite.T(), "`test`", suite.mysql.Escape("test"))
+	assert.Equal(suite.T(), []string{"`test`"}, suite.mysql.EscapeAll([]string{"test"}))
+	assert.Equal(suite.T(), "?", suite.mysql.Placeholder())
+	assert.Equal(suite.T(), []string{"?", "?"}, suite.mysql.Placeholders(5, 10))
+	assert.Equal(suite.T(), "mysql", suite.mysql.Driver())
 	suite.mysql.Reset() // does nothing
 }
 
 func (suite *DialectTestSuite) TestPostgresDialect() {
-	assert.Equal(suite.T(), suite.postgres.SupportsUnsigned(), false)
-	assert.Equal(suite.T(), suite.postgres.Escape("test"), "test")
-	assert.Equal(suite.T(), suite.postgres.Escaping(), false)
+	assert.Equal(suite.T(), false, suite.postgres.SupportsUnsigned())
+	assert.Equal(suite.T(), "test", suite.postgres.Escape("test"))
+	assert.Equal(suite.T(), false, suite.postgres.Escaping())
 	suite.postgres.SetEscaping(true)
-	assert.Equal(suite.T(), suite.postgres.Escaping(), true)
-	assert.Equal(suite.T(), suite.postgres.Escape("test"), "\"test\"")
-	assert.Equal(suite.T(), suite.postgres.EscapeAll([]string{"test"}), []string{"\"test\""})
-	assert.Equal(suite.T(), suite.postgres.Placeholder(), "$1")
-	assert.Equal(suite.T(), suite.postgres.Placeholder(), "$2")
+	assert.Equal(suite.T(), true, suite.postgres.Escaping())
+	assert.Equal(suite.T(), "\"test\"", suite.postgres.Escape("test"))
+	assert.Equal(suite.T(), []string{"\"test\""}, suite.postgres.EscapeAll([]string{"test"}))
+	assert.Equal(suite.T(), "$1", suite.postgres.Placeholder())
+	assert.Equal(suite.T(), "$2", suite.postgres.Placeholder())
 	suite.postgres.Reset()
-	assert.Equal(suite.T(), suite.postgres.Placeholder(), "$1")
-	assert.Equal(suite.T(), suite.postgres.Placeholders(5, 10), []string{"$2", "$3"})
-	assert.Equal(suite.T(), suite.postgres.Driver(), "postgres")
+	assert.Equal(suite.T(), "$1", suite.postgres.Placeholder())
+	assert.Equal(suite.T(), []string{"$2", "$3"}, suite.postgres.Placeholders(5, 10))
+	assert.Equal(suite.T(), "postgres", suite.postgres.Driver())
 
 	col := Column("autoinc", Int()).AutoIncrement()
-	assert.Equal(suite.T(),
-		suite.postgres.AutoIncrement(&col),
-		"SERIAL")
+	assert.Equal(suite.T(), "SERIAL", suite.postgres.AutoIncrement(&col))
 
 	col = Column("autoinc", BigInt()).AutoIncrement()
-	assert.Equal(suite.T(),
-		suite.postgres.AutoIncrement(&col),
-		"BIGSERIAL")
+	assert.Equal(suite.T(), "BIGSERIAL", suite.postgres.AutoIncrement(&col))
 
 	col = Column("autoinc", SmallInt()).AutoIncrement()
-	assert.Equal(suite.T(),
-		suite.postgres.AutoIncrement(&col),
-		"SMALLSERIAL")
+	assert.Equal(suite.T(), "SMALLSERIAL", suite.postgres.AutoIncrement(&col))
 }
 
 func (suite *DialectTestSuite) TestSqliteDialect() {
-	assert.Equal(suite.T(), suite.sqlite.SupportsUnsigned(), false)
-	assert.Equal(suite.T(), suite.sqlite.Escape("test"), "test")
-	assert.Equal(suite.T(), suite.sqlite.Escaping(), false)
+	assert.Equal(suite.T(), false, suite.sqlite.SupportsUnsigned())
+	assert.Equal(suite.T(), "test", suite.sqlite.Escape("test"))
+	assert.Equal(suite.T(), false, suite.sqlite.Escaping())
 	suite.sqlite.SetEscaping(true)
-	assert.Equal(suite.T(), suite.sqlite.Escaping(), true)
-	assert.Equal(suite.T(), suite.sqlite.Escape("test"), "test")
-	assert.Equal(suite.T(), suite.sqlite.EscapeAll([]string{"test"}), []string{"test"})
-	assert.Equal(suite.T(), suite.sqlite.Placeholder(), "?")
-	assert.Equal(suite.T(), suite.sqlite.Placeholders(5, 10), []string{"?", "?"})
-	assert.Equal(suite.T(), suite.sqlite.Driver(), "sqlite3")
+	assert.Equal(suite.T(), true, suite.sqlite.Escaping())
+	assert.Equal(suite.T(), "test", suite.sqlite.Escape("test"))
+	assert.Equal(suite.T(), []string{"test"}, suite.sqlite.EscapeAll([]string{"test"}))
+	assert.Equal(suite.T(), "?", suite.sqlite.Placeholder())
+	assert.Equal(suite.T(), []string{"?", "?"}, suite.sqlite.Placeholders(5, 10))
+	assert.Equal(suite.T(), "sqlite3", suite.sqlite.Driver())
 	suite.sqlite.Reset() // does nothing
 }
 

--- a/engine_test.go
+++ b/engine_test.go
@@ -9,16 +9,16 @@ import (
 func TestEngine(t *testing.T) {
 	engine, err := NewEngine("postgres", "user=root dbname=pqtest")
 
-	assert.Equal(t, err, nil)
-	assert.Equal(t, engine.Driver(), "postgres")
-	assert.Equal(t, engine.Ping(), engine.DB().Ping())
-	assert.Equal(t, engine.Dsn(), "user=root dbname=pqtest")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "postgres", engine.Driver())
+	assert.Equal(t, engine.DB().Ping(), engine.Ping())
+	assert.Equal(t, "user=root dbname=pqtest", engine.Dsn())
 }
 
 func TestInvalidEngine(t *testing.T) {
 	engine, err := NewEngine("invalid", "")
-	assert.NotEqual(t, err, nil)
-	assert.Equal(t, engine, (*Engine)(nil))
+	assert.NotEqual(t, nil, err)
+	assert.Equal(t, (*Engine)(nil), engine)
 }
 
 func TestEngineExec(t *testing.T) {
@@ -40,7 +40,7 @@ func TestEngineExec(t *testing.T) {
 	assert.Nil(t, err)
 
 	res, err := engine.Exec(ins)
-	assert.Equal(t, res, nil)
+	assert.Equal(t, nil, res)
 	assert.NotNil(t, err)
 }
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -26,5 +26,5 @@ func TestLogger(t *testing.T) {
 	_, err = db.Engine().Exec(actors.Insert().Values(map[string]interface{}{"id": 10}))
 	assert.Nil(t, err)
 
-	assert.Equal(t, db.Engine().Logger().LogFlags(), LQuery|LBindings)
+	assert.Equal(t, LQuery|LBindings, db.Engine().Logger().LogFlags())
 }

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -100,10 +100,10 @@ func TestMapperWithDBTag(t *testing.T) {
 	assert.Contains(t, ddl, "PRIMARY KEY(_id)")
 
 	m := mapper.ToMap(User{ID: "cba0667d-8c76-4999-9a55-84ffe572fb23", Email: "aras@slicebit.com"}, false)
-	assert.Equal(t, m, map[string]interface{}{
+	assert.Equal(t, map[string]interface{}{
 		"_id":   "cba0667d-8c76-4999-9a55-84ffe572fb23",
 		"email": "aras@slicebit.com",
-	})
+	}, m)
 }
 
 func TestMapperPostgresAutoIncrement(t *testing.T) {
@@ -154,7 +154,7 @@ func TestNonZeroStruct(t *testing.T) {
 
 	mapper := Mapper()
 	m := mapper.ToMap(User{5}, false)
-	assert.Equal(t, m, map[string]interface{}{"id": 5})
+	assert.Equal(t, map[string]interface{}{"id": 5}, m)
 }
 
 func TestMapperUtilFuncs(t *testing.T) {
@@ -166,41 +166,41 @@ func TestMapperUtilFuncs(t *testing.T) {
 	mapper := Mapper()
 
 	kv := mapper.ToMap(UserErr{}, false)
-	assert.Equal(t, kv, map[string]interface{}{})
+	assert.Equal(t, map[string]interface{}{}, kv)
 }
 
 func TestMapperTypes(t *testing.T) {
 	mapper := Mapper()
 
-	assert.Equal(t, mapper.ToType("string", ""), Varchar().Size(255))
+	assert.Equal(t, Varchar().Size(255), mapper.ToType("string", ""))
 
-	assert.Equal(t, mapper.ToType("int", ""), Int())
+	assert.Equal(t, Int(), mapper.ToType("int", ""))
 
-	assert.Equal(t, mapper.ToType("int8", ""), TinyInt())
+	assert.Equal(t, TinyInt(), mapper.ToType("int8", ""))
 
-	assert.Equal(t, mapper.ToType("int16", ""), SmallInt())
+	assert.Equal(t, SmallInt(), mapper.ToType("int16", ""))
 
-	assert.Equal(t, mapper.ToType("int32", ""), Int())
+	assert.Equal(t, Int(), mapper.ToType("int32", ""))
 
-	assert.Equal(t, mapper.ToType("int64", ""), BigInt())
+	assert.Equal(t, BigInt(), mapper.ToType("int64", ""))
 
-	assert.Equal(t, mapper.ToType("uint", ""), Int().Unsigned())
+	assert.Equal(t, Int().Unsigned(), mapper.ToType("uint", ""))
 
-	assert.Equal(t, mapper.ToType("uint8", ""), TinyInt().Unsigned())
+	assert.Equal(t, TinyInt().Unsigned(), mapper.ToType("uint8", ""))
 
-	assert.Equal(t, mapper.ToType("uint16", ""), SmallInt().Unsigned())
+	assert.Equal(t, SmallInt().Unsigned(), mapper.ToType("uint16", ""))
 
-	assert.Equal(t, mapper.ToType("uint32", ""), Int().Unsigned())
+	assert.Equal(t, Int().Unsigned(), mapper.ToType("uint32", ""))
 
-	assert.Equal(t, mapper.ToType("uint64", ""), BigInt().Unsigned())
+	assert.Equal(t, BigInt().Unsigned(), mapper.ToType("uint64", ""))
 
-	assert.Equal(t, mapper.ToType("float32", ""), Float())
+	assert.Equal(t, Float(), mapper.ToType("float32", ""))
 
-	assert.Equal(t, mapper.ToType("float64", ""), Float())
+	assert.Equal(t, Float(), mapper.ToType("float64", ""))
 
-	assert.Equal(t, mapper.ToType("bool", ""), Boolean())
+	assert.Equal(t, Boolean(), mapper.ToType("bool", ""))
 
-	assert.Equal(t, mapper.ToType("time.Time", ""), Timestamp())
+	assert.Equal(t, Timestamp(), mapper.ToType("time.Time", ""))
 
-	assert.Equal(t, mapper.ToType("*time.Time", ""), Timestamp())
+	assert.Equal(t, Timestamp(), mapper.ToType("*time.Time", ""))
 }

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -39,7 +39,7 @@ func TestMetadataAddError(t *testing.T) {
 	metadata := MetaData()
 
 	assert.Panics(t, func() { metadata.Add(UserMetadataError{}) })
-	assert.Equal(t, len(metadata.Tables()), 0)
+	assert.Equal(t, 0, len(metadata.Tables()))
 }
 
 func TestMetadataAddTable(t *testing.T) {
@@ -49,9 +49,9 @@ func TestMetadataAddTable(t *testing.T) {
 
 	metadata.AddTable(table)
 
-	assert.Equal(t, metadata.Tables(), []TableElem{table})
+	assert.Equal(t, []TableElem{table}, metadata.Tables())
 
-	assert.Equal(t, metadata.Table("user").Name, "user")
+	assert.Equal(t, "user", metadata.Table("user").Name)
 }
 
 func TestMetadataTable(t *testing.T) {

--- a/mysql_test.go
+++ b/mysql_test.go
@@ -73,9 +73,9 @@ func (suite *MysqlTestSuite) TestMysql() {
 
 	suite.db.Find(&User{ID: "b6f8bfe3-a830-441a-a097-1777e6bfae95"}).One(&user)
 
-	assert.Equal(suite.T(), user.Email, "jack@nicholson.com")
-	assert.Equal(suite.T(), user.FullName, "Jack Nicholson")
-	assert.Equal(suite.T(), user.Bio.String, "Jack Nicholson, an American actor, producer, screen-writer and director, is a three-time Academy Award winner and twelve-time nominee.")
+	assert.Equal(suite.T(), "jack@nicholson.com", user.Email)
+	assert.Equal(suite.T(), "Jack Nicholson", user.FullName)
+	assert.Equal(suite.T(), "Jack Nicholson, an American actor, producer, screen-writer and director, is a three-time Academy Award winner and twelve-time nominee.", user.Bio.String)
 
 	// select using join
 	sessions := []Session{}
@@ -85,11 +85,11 @@ func (suite *MysqlTestSuite) TestMysql() {
 		All(&sessions)
 
 	assert.Nil(suite.T(), err)
-	assert.Equal(suite.T(), len(sessions), 1)
+	assert.Equal(suite.T(), 1, len(sessions))
 
-	assert.Equal(suite.T(), sessions[0].ID, int64(1))
-	assert.Equal(suite.T(), sessions[0].UserID, "b6f8bfe3-a830-441a-a097-1777e6bfae95")
-	assert.Equal(suite.T(), sessions[0].AuthToken, "e4968197-6137-47a4-ba79-690d8c552248")
+	assert.Equal(suite.T(), int64(1), sessions[0].ID)
+	assert.Equal(suite.T(), "b6f8bfe3-a830-441a-a097-1777e6bfae95", sessions[0].UserID)
+	assert.Equal(suite.T(), "e4968197-6137-47a4-ba79-690d8c552248", sessions[0].AuthToken)
 
 	user.Bio = sql.NullString{String: "nil", Valid: false}
 	suite.db.Add(user)
@@ -98,7 +98,7 @@ func (suite *MysqlTestSuite) TestMysql() {
 	assert.Nil(suite.T(), err)
 
 	suite.db.Find(&User{ID: "b6f8bfe3-a830-441a-a097-1777e6bfae95"}).One(&user)
-	assert.Equal(suite.T(), user.Bio, sql.NullString{String: "", Valid: false})
+	assert.Equal(suite.T(), sql.NullString{String: "", Valid: false}, user.Bio)
 
 	// delete session
 	suite.db.Delete(&Session{AuthToken: "99e591f8-1025-41ef-a833-6904a0f89a38"})

--- a/postgres_test.go
+++ b/postgres_test.go
@@ -109,16 +109,16 @@ func (suite *PostgresTestSuite) TestPostgres() {
 	for rows.Next() {
 		rowLength++
 	}
-	assert.Equal(suite.T(), rowLength, 1)
+	assert.Equal(suite.T(), 1, rowLength)
 
 	// find user using session api's Find()
 	var user User
 
 	suite.db.Find(&User{ID: "b6f8bfe3-a830-441a-a097-1777e6bfae95"}).One(&user)
 
-	assert.Equal(suite.T(), user.Email, "jack@nicholson.com")
-	assert.Equal(suite.T(), user.FullName, "Jack Nicholson")
-	assert.Equal(suite.T(), user.Bio.String, "Jack Nicholson, an American actor, producer, screen-writer and director, is a three-time Academy Award winner and twelve-time nominee.")
+	assert.Equal(suite.T(), "jack@nicholson.com", user.Email)
+	assert.Equal(suite.T(), "Jack Nicholson", user.FullName)
+	assert.Equal(suite.T(), "Jack Nicholson, an American actor, producer, screen-writer and director, is a three-time Academy Award winner and twelve-time nominee.", user.Bio.String)
 
 	// select using join
 	sessions := []Session{}
@@ -134,11 +134,11 @@ func (suite *PostgresTestSuite) TestPostgres() {
 		All(&sessions)
 
 	assert.Nil(suite.T(), err)
-	assert.Equal(suite.T(), len(sessions), 1)
+	assert.Equal(suite.T(), 1, len(sessions))
 
-	assert.Equal(suite.T(), sessions[0].ID, int64(1))
-	assert.Equal(suite.T(), sessions[0].UserID, "b6f8bfe3-a830-441a-a097-1777e6bfae95")
-	assert.Equal(suite.T(), sessions[0].AuthToken, "e4968197-6137-47a4-ba79-690d8c552248")
+	assert.Equal(suite.T(), int64(1), sessions[0].ID)
+	assert.Equal(suite.T(), "b6f8bfe3-a830-441a-a097-1777e6bfae95", sessions[0].UserID)
+	assert.Equal(suite.T(), "e4968197-6137-47a4-ba79-690d8c552248", sessions[0].AuthToken)
 
 	// update user
 	user.Bio = sql.NullString{String: "nil", Valid: false}
@@ -148,7 +148,7 @@ func (suite *PostgresTestSuite) TestPostgres() {
 	assert.Nil(suite.T(), err)
 
 	suite.db.Find(&User{ID: "b6f8bfe3-a830-441a-a097-1777e6bfae95"}).One(&user)
-	assert.Equal(suite.T(), user.Bio, sql.NullString{String: "", Valid: false})
+	assert.Equal(suite.T(), sql.NullString{String: "", Valid: false}, user.Bio)
 
 	// delete session
 	suite.db.Delete(&Session{AuthToken: "99e591f8-1025-41ef-a833-6904a0f89a38"})

--- a/select_test.go
+++ b/select_test.go
@@ -46,13 +46,13 @@ func (suite *SelectTestSuite) TestSimpleSelect() {
 
 	var statement *Stmt
 	statement = sel.Build(suite.sqlite)
-	assert.Equal(suite.T(), statement.SQL(), "SELECT id\nFROM users;")
+	assert.Equal(suite.T(), "SELECT id\nFROM users;", statement.SQL())
 
 	statement = sel.Build(suite.mysql)
-	assert.Equal(suite.T(), statement.SQL(), "SELECT `id`\nFROM `users`;")
+	assert.Equal(suite.T(), "SELECT `id`\nFROM `users`;", statement.SQL())
 
 	statement = sel.Build(suite.postgres)
-	assert.Equal(suite.T(), statement.SQL(), "SELECT \"id\"\nFROM \"users\";")
+	assert.Equal(suite.T(), "SELECT \"id\"\nFROM \"users\";", statement.SQL())
 }
 
 func (suite *SelectTestSuite) TestSelectWhere() {
@@ -68,16 +68,16 @@ func (suite *SelectTestSuite) TestSelectWhere() {
 	var statement *Stmt
 
 	statement = sel.Build(suite.sqlite)
-	assert.Equal(suite.T(), statement.SQL(), "SELECT id\nFROM users\nWHERE (users.email = ? AND users.id != ?);")
-	assert.Equal(suite.T(), statement.Bindings(), []interface{}{"al@pacino.com", 5})
+	assert.Equal(suite.T(), "SELECT id\nFROM users\nWHERE (users.email = ? AND users.id != ?);", statement.SQL())
+	assert.Equal(suite.T(), []interface{}{"al@pacino.com", 5}, statement.Bindings())
 
 	statement = sel.Build(suite.mysql)
-	assert.Equal(suite.T(), statement.SQL(), "SELECT `id`\nFROM `users`\nWHERE (`users`.`email` = ? AND `users`.`id` != ?);")
-	assert.Equal(suite.T(), statement.Bindings(), []interface{}{"al@pacino.com", 5})
+	assert.Equal(suite.T(), "SELECT `id`\nFROM `users`\nWHERE (`users`.`email` = ? AND `users`.`id` != ?);", statement.SQL())
+	assert.Equal(suite.T(), []interface{}{"al@pacino.com", 5}, statement.Bindings())
 
 	statement = sel.Build(suite.postgres)
-	assert.Equal(suite.T(), statement.SQL(), "SELECT \"id\"\nFROM \"users\"\nWHERE (\"users\".\"email\" = $1 AND \"users\".\"id\" != $2);")
-	assert.Equal(suite.T(), statement.Bindings(), []interface{}{"al@pacino.com", 5})
+	assert.Equal(suite.T(), "SELECT \"id\"\nFROM \"users\"\nWHERE (\"users\".\"email\" = $1 AND \"users\".\"id\" != $2);", statement.SQL())
+	assert.Equal(suite.T(), []interface{}{"al@pacino.com", 5}, statement.Bindings())
 }
 
 func (suite *SelectTestSuite) TestOrderByLimit() {
@@ -89,16 +89,16 @@ func (suite *SelectTestSuite) TestOrderByLimit() {
 
 	var statement *Stmt
 	statement = selOrderByDesc.Build(suite.sqlite)
-	assert.Equal(suite.T(), statement.SQL(), "SELECT id\nFROM sessions\nWHERE sessions.user_id = ?\nORDER BY id DESC\nLIMIT 20 OFFSET 0;")
-	assert.Equal(suite.T(), statement.Bindings(), []interface{}{5})
+	assert.Equal(suite.T(), "SELECT id\nFROM sessions\nWHERE sessions.user_id = ?\nORDER BY id DESC\nLIMIT 20 OFFSET 0;", statement.SQL())
+	assert.Equal(suite.T(), []interface{}{5}, statement.Bindings())
 
 	statement = selOrderByDesc.Build(suite.mysql)
-	assert.Equal(suite.T(), statement.SQL(), "SELECT `id`\nFROM `sessions`\nWHERE `sessions`.`user_id` = ?\nORDER BY `id` DESC\nLIMIT 20 OFFSET 0;")
-	assert.Equal(suite.T(), statement.Bindings(), []interface{}{5})
+	assert.Equal(suite.T(), "SELECT `id`\nFROM `sessions`\nWHERE `sessions`.`user_id` = ?\nORDER BY `id` DESC\nLIMIT 20 OFFSET 0;", statement.SQL())
+	assert.Equal(suite.T(), []interface{}{5}, statement.Bindings())
 
 	statement = selOrderByDesc.Build(suite.postgres)
-	assert.Equal(suite.T(), statement.SQL(), "SELECT \"id\"\nFROM \"sessions\"\nWHERE \"sessions\".\"user_id\" = $1\nORDER BY \"id\" DESC\nLIMIT 20 OFFSET 0;")
-	assert.Equal(suite.T(), statement.Bindings(), []interface{}{5})
+	assert.Equal(suite.T(), "SELECT \"id\"\nFROM \"sessions\"\nWHERE \"sessions\".\"user_id\" = $1\nORDER BY \"id\" DESC\nLIMIT 20 OFFSET 0;", statement.SQL())
+	assert.Equal(suite.T(), []interface{}{5}, statement.Bindings())
 
 	selWithoutOrder := Select(suite.sessions.C("id")).
 		From(suite.sessions).
@@ -106,16 +106,16 @@ func (suite *SelectTestSuite) TestOrderByLimit() {
 		OrderBy(suite.sessions.C("id"))
 
 	statement = selWithoutOrder.Build(suite.sqlite)
-	assert.Equal(suite.T(), statement.SQL(), "SELECT id\nFROM sessions\nWHERE sessions.user_id = ?\nORDER BY id ASC;")
-	assert.Equal(suite.T(), statement.Bindings(), []interface{}{5})
+	assert.Equal(suite.T(), "SELECT id\nFROM sessions\nWHERE sessions.user_id = ?\nORDER BY id ASC;", statement.SQL())
+	assert.Equal(suite.T(), []interface{}{5}, statement.Bindings())
 
 	statement = selWithoutOrder.Build(suite.mysql)
-	assert.Equal(suite.T(), statement.SQL(), "SELECT `id`\nFROM `sessions`\nWHERE `sessions`.`user_id` = ?\nORDER BY `id` ASC;")
-	assert.Equal(suite.T(), statement.Bindings(), []interface{}{5})
+	assert.Equal(suite.T(), "SELECT `id`\nFROM `sessions`\nWHERE `sessions`.`user_id` = ?\nORDER BY `id` ASC;", statement.SQL())
+	assert.Equal(suite.T(), []interface{}{5}, statement.Bindings())
 
 	statement = selWithoutOrder.Build(suite.postgres)
-	assert.Equal(suite.T(), statement.SQL(), "SELECT \"id\"\nFROM \"sessions\"\nWHERE \"sessions\".\"user_id\" = $1\nORDER BY \"id\" ASC;")
-	assert.Equal(suite.T(), statement.Bindings(), []interface{}{5})
+	assert.Equal(suite.T(), "SELECT \"id\"\nFROM \"sessions\"\nWHERE \"sessions\".\"user_id\" = $1\nORDER BY \"id\" ASC;", statement.SQL())
+	assert.Equal(suite.T(), []interface{}{5}, statement.Bindings())
 
 	selOrderByAsc := Select(suite.sessions.C("id")).
 		From(suite.sessions).
@@ -123,16 +123,16 @@ func (suite *SelectTestSuite) TestOrderByLimit() {
 		OrderBy(suite.sessions.C("id")).Asc()
 
 	statement = selOrderByAsc.Build(suite.sqlite)
-	assert.Equal(suite.T(), statement.SQL(), "SELECT id\nFROM sessions\nWHERE sessions.user_id = ?\nORDER BY id ASC;")
-	assert.Equal(suite.T(), statement.Bindings(), []interface{}{5})
+	assert.Equal(suite.T(), "SELECT id\nFROM sessions\nWHERE sessions.user_id = ?\nORDER BY id ASC;", statement.SQL())
+	assert.Equal(suite.T(), []interface{}{5}, statement.Bindings())
 
 	statement = selOrderByAsc.Build(suite.mysql)
-	assert.Equal(suite.T(), statement.SQL(), "SELECT `id`\nFROM `sessions`\nWHERE `sessions`.`user_id` = ?\nORDER BY `id` ASC;")
-	assert.Equal(suite.T(), statement.Bindings(), []interface{}{5})
+	assert.Equal(suite.T(), "SELECT `id`\nFROM `sessions`\nWHERE `sessions`.`user_id` = ?\nORDER BY `id` ASC;", statement.SQL())
+	assert.Equal(suite.T(), []interface{}{5}, statement.Bindings())
 
 	statement = selOrderByAsc.Build(suite.postgres)
-	assert.Equal(suite.T(), statement.SQL(), "SELECT \"id\"\nFROM \"sessions\"\nWHERE \"sessions\".\"user_id\" = $1\nORDER BY \"id\" ASC;")
-	assert.Equal(suite.T(), statement.Bindings(), []interface{}{5})
+	assert.Equal(suite.T(), "SELECT \"id\"\nFROM \"sessions\"\nWHERE \"sessions\".\"user_id\" = $1\nORDER BY \"id\" ASC;", statement.SQL())
+	assert.Equal(suite.T(), []interface{}{5}, statement.Bindings())
 }
 
 func (suite *SelectTestSuite) TestJoin() {
@@ -146,16 +146,16 @@ func (suite *SelectTestSuite) TestJoin() {
 	var statement *Stmt
 
 	statement = selInnerJoin.Build(suite.sqlite)
-	assert.Equal(suite.T(), statement.SQL(), "SELECT sessions.id, sessions.auth_token\nFROM sessions\nINNER JOIN users ON sessions.user_id = users.id\nWHERE sessions.user_id = ?;")
-	assert.Equal(suite.T(), statement.Bindings(), []interface{}{5})
+	assert.Equal(suite.T(), "SELECT sessions.id, sessions.auth_token\nFROM sessions\nINNER JOIN users ON sessions.user_id = users.id\nWHERE sessions.user_id = ?;", statement.SQL())
+	assert.Equal(suite.T(), []interface{}{5}, statement.Bindings())
 
 	statement = selInnerJoin.Build(suite.mysql)
-	assert.Equal(suite.T(), statement.SQL(), "SELECT `sessions`.`id`, `sessions`.`auth_token`\nFROM `sessions`\nINNER JOIN `users` ON `sessions`.`user_id` = `users`.`id`\nWHERE `sessions`.`user_id` = ?;")
-	assert.Equal(suite.T(), statement.Bindings(), []interface{}{5})
+	assert.Equal(suite.T(), "SELECT `sessions`.`id`, `sessions`.`auth_token`\nFROM `sessions`\nINNER JOIN `users` ON `sessions`.`user_id` = `users`.`id`\nWHERE `sessions`.`user_id` = ?;", statement.SQL())
+	assert.Equal(suite.T(), []interface{}{5}, statement.Bindings())
 
 	statement = selInnerJoin.Build(suite.postgres)
-	assert.Equal(suite.T(), statement.SQL(), "SELECT \"sessions\".\"id\", \"sessions\".\"auth_token\"\nFROM \"sessions\"\nINNER JOIN \"users\" ON \"sessions\".\"user_id\" = \"users\".\"id\"\nWHERE \"sessions\".\"user_id\" = $1;")
-	assert.Equal(suite.T(), statement.Bindings(), []interface{}{5})
+	assert.Equal(suite.T(), "SELECT \"sessions\".\"id\", \"sessions\".\"auth_token\"\nFROM \"sessions\"\nINNER JOIN \"users\" ON \"sessions\".\"user_id\" = \"users\".\"id\"\nWHERE \"sessions\".\"user_id\" = $1;", statement.SQL())
+	assert.Equal(suite.T(), []interface{}{5}, statement.Bindings())
 
 	// left join
 	selLeftJoin := Select(suite.sessions.C("id"), suite.sessions.C("auth_token")).
@@ -164,16 +164,16 @@ func (suite *SelectTestSuite) TestJoin() {
 		Where(Eq(suite.sessions.C("user_id"), 5))
 
 	statement = selLeftJoin.Build(suite.sqlite)
-	assert.Equal(suite.T(), statement.SQL(), "SELECT sessions.id, sessions.auth_token\nFROM sessions\nLEFT OUTER JOIN users ON sessions.user_id = users.id\nWHERE sessions.user_id = ?;")
-	assert.Equal(suite.T(), statement.Bindings(), []interface{}{5})
+	assert.Equal(suite.T(), "SELECT sessions.id, sessions.auth_token\nFROM sessions\nLEFT OUTER JOIN users ON sessions.user_id = users.id\nWHERE sessions.user_id = ?;", statement.SQL())
+	assert.Equal(suite.T(), []interface{}{5}, statement.Bindings())
 
 	statement = selLeftJoin.Build(suite.mysql)
-	assert.Equal(suite.T(), statement.SQL(), "SELECT `sessions`.`id`, `sessions`.`auth_token`\nFROM `sessions`\nLEFT OUTER JOIN `users` ON `sessions`.`user_id` = `users`.`id`\nWHERE `sessions`.`user_id` = ?;")
-	assert.Equal(suite.T(), statement.Bindings(), []interface{}{5})
+	assert.Equal(suite.T(), "SELECT `sessions`.`id`, `sessions`.`auth_token`\nFROM `sessions`\nLEFT OUTER JOIN `users` ON `sessions`.`user_id` = `users`.`id`\nWHERE `sessions`.`user_id` = ?;", statement.SQL())
+	assert.Equal(suite.T(), []interface{}{5}, statement.Bindings())
 
 	statement = selLeftJoin.Build(suite.postgres)
-	assert.Equal(suite.T(), statement.SQL(), "SELECT \"sessions\".\"id\", \"sessions\".\"auth_token\"\nFROM \"sessions\"\nLEFT OUTER JOIN \"users\" ON \"sessions\".\"user_id\" = \"users\".\"id\"\nWHERE \"sessions\".\"user_id\" = $1;")
-	assert.Equal(suite.T(), statement.Bindings(), []interface{}{5})
+	assert.Equal(suite.T(), "SELECT \"sessions\".\"id\", \"sessions\".\"auth_token\"\nFROM \"sessions\"\nLEFT OUTER JOIN \"users\" ON \"sessions\".\"user_id\" = \"users\".\"id\"\nWHERE \"sessions\".\"user_id\" = $1;", statement.SQL())
+	assert.Equal(suite.T(), []interface{}{5}, statement.Bindings())
 
 	// right join
 	selRightJoin := Select(suite.sessions.C("id")).
@@ -182,16 +182,16 @@ func (suite *SelectTestSuite) TestJoin() {
 		Where(Eq(suite.sessions.C("user_id"), 5))
 
 	statement = selRightJoin.Build(suite.sqlite)
-	assert.Equal(suite.T(), statement.SQL(), "SELECT sessions.id\nFROM sessions\nRIGHT OUTER JOIN users ON sessions.user_id = users.id\nWHERE sessions.user_id = ?;")
-	assert.Equal(suite.T(), statement.Bindings(), []interface{}{5})
+	assert.Equal(suite.T(), "SELECT sessions.id\nFROM sessions\nRIGHT OUTER JOIN users ON sessions.user_id = users.id\nWHERE sessions.user_id = ?;", statement.SQL())
+	assert.Equal(suite.T(), []interface{}{5}, statement.Bindings())
 
 	statement = selRightJoin.Build(suite.mysql)
-	assert.Equal(suite.T(), statement.SQL(), "SELECT `sessions`.`id`\nFROM `sessions`\nRIGHT OUTER JOIN `users` ON `sessions`.`user_id` = `users`.`id`\nWHERE `sessions`.`user_id` = ?;")
-	assert.Equal(suite.T(), statement.Bindings(), []interface{}{5})
+	assert.Equal(suite.T(), "SELECT `sessions`.`id`\nFROM `sessions`\nRIGHT OUTER JOIN `users` ON `sessions`.`user_id` = `users`.`id`\nWHERE `sessions`.`user_id` = ?;", statement.SQL())
+	assert.Equal(suite.T(), []interface{}{5}, statement.Bindings())
 
 	statement = selRightJoin.Build(suite.postgres)
-	assert.Equal(suite.T(), statement.SQL(), "SELECT \"sessions\".\"id\"\nFROM \"sessions\"\nRIGHT OUTER JOIN \"users\" ON \"sessions\".\"user_id\" = \"users\".\"id\"\nWHERE \"sessions\".\"user_id\" = $1;")
-	assert.Equal(suite.T(), statement.Bindings(), []interface{}{5})
+	assert.Equal(suite.T(), "SELECT \"sessions\".\"id\"\nFROM \"sessions\"\nRIGHT OUTER JOIN \"users\" ON \"sessions\".\"user_id\" = \"users\".\"id\"\nWHERE \"sessions\".\"user_id\" = $1;", statement.SQL())
+	assert.Equal(suite.T(), []interface{}{5}, statement.Bindings())
 
 	// cross join
 	selCrossJoin := Select(suite.sessions.C("id")).
@@ -200,16 +200,16 @@ func (suite *SelectTestSuite) TestJoin() {
 		Where(Eq(suite.sessions.C("user_id"), 5))
 
 	statement = selCrossJoin.Build(suite.sqlite)
-	assert.Equal(suite.T(), statement.SQL(), "SELECT sessions.id\nFROM sessions\nCROSS JOIN users\nWHERE sessions.user_id = ?;")
-	assert.Equal(suite.T(), statement.Bindings(), []interface{}{5})
+	assert.Equal(suite.T(), "SELECT sessions.id\nFROM sessions\nCROSS JOIN users\nWHERE sessions.user_id = ?;", statement.SQL())
+	assert.Equal(suite.T(), []interface{}{5}, statement.Bindings())
 
 	statement = selCrossJoin.Build(suite.mysql)
-	assert.Equal(suite.T(), statement.SQL(), "SELECT `sessions`.`id`\nFROM `sessions`\nCROSS JOIN `users`\nWHERE `sessions`.`user_id` = ?;")
-	assert.Equal(suite.T(), statement.Bindings(), []interface{}{5})
+	assert.Equal(suite.T(), "SELECT `sessions`.`id`\nFROM `sessions`\nCROSS JOIN `users`\nWHERE `sessions`.`user_id` = ?;", statement.SQL())
+	assert.Equal(suite.T(), []interface{}{5}, statement.Bindings())
 
 	statement = selCrossJoin.Build(suite.postgres)
-	assert.Equal(suite.T(), statement.SQL(), "SELECT \"sessions\".\"id\"\nFROM \"sessions\"\nCROSS JOIN \"users\"\nWHERE \"sessions\".\"user_id\" = $1;")
-	assert.Equal(suite.T(), statement.Bindings(), []interface{}{5})
+	assert.Equal(suite.T(), "SELECT \"sessions\".\"id\"\nFROM \"sessions\"\nCROSS JOIN \"users\"\nWHERE \"sessions\".\"user_id\" = $1;", statement.SQL())
+	assert.Equal(suite.T(), []interface{}{5}, statement.Bindings())
 }
 
 func (suite *SelectTestSuite) TestGroupByHaving() {
@@ -220,16 +220,16 @@ func (suite *SelectTestSuite) TestGroupByHaving() {
 
 	var statement *Stmt
 	statement = sel.Build(suite.sqlite)
-	assert.Equal(suite.T(), statement.SQL(), "SELECT COUNT(id)\nFROM sessions\nGROUP BY user_id\nHAVING SUM(id) > ?;")
-	assert.Equal(suite.T(), statement.Bindings(), []interface{}{4})
+	assert.Equal(suite.T(), "SELECT COUNT(id)\nFROM sessions\nGROUP BY user_id\nHAVING SUM(id) > ?;", statement.SQL())
+	assert.Equal(suite.T(), []interface{}{4}, statement.Bindings())
 
 	statement = sel.Build(suite.mysql)
-	assert.Equal(suite.T(), statement.SQL(), "SELECT COUNT(`id`)\nFROM `sessions`\nGROUP BY `user_id`\nHAVING SUM(`id`) > ?;")
-	assert.Equal(suite.T(), statement.Bindings(), []interface{}{4})
+	assert.Equal(suite.T(), "SELECT COUNT(`id`)\nFROM `sessions`\nGROUP BY `user_id`\nHAVING SUM(`id`) > ?;", statement.SQL())
+	assert.Equal(suite.T(), []interface{}{4}, statement.Bindings())
 
 	statement = sel.Build(suite.postgres)
-	assert.Equal(suite.T(), statement.SQL(), "SELECT COUNT(\"id\")\nFROM \"sessions\"\nGROUP BY \"user_id\"\nHAVING SUM(\"id\") > $1;")
-	assert.Equal(suite.T(), statement.Bindings(), []interface{}{4})
+	assert.Equal(suite.T(), "SELECT COUNT(\"id\")\nFROM \"sessions\"\nGROUP BY \"user_id\"\nHAVING SUM(\"id\") > $1;", statement.SQL())
+	assert.Equal(suite.T(), []interface{}{4}, statement.Bindings())
 }
 
 func TestSelectTestSuite(t *testing.T) {

--- a/session_test.go
+++ b/session_test.go
@@ -86,8 +86,8 @@ func TestSessionWrappings(t *testing.T) {
 		Filter(sessions.C("id").Eq("9efbc9ab-7914-426c-8818-7d40b0427c8f")).
 		Statement()
 
-	assert.Equal(t, selInnerJoin.SQL(), "SELECT sessions.id, sessions.created_at\nFROM sessions\nINNER JOIN users ON sessions.user_id = users.id\nWHERE (sessions.id = $1);")
-	assert.Equal(t, selInnerJoin.Bindings(), []interface{}{"9efbc9ab-7914-426c-8818-7d40b0427c8f"})
+	assert.Equal(t, "SELECT sessions.id, sessions.created_at\nFROM sessions\nINNER JOIN users ON sessions.user_id = users.id\nWHERE (sessions.id = $1);", selInnerJoin.SQL())
+	assert.Equal(t, []interface{}{"9efbc9ab-7914-426c-8818-7d40b0427c8f"}, selInnerJoin.Bindings())
 
 	selLeftJoin := qb.Query(sessions.All()...).
 		LeftJoin(users, sessions.C("user_id"), users.C("id")).
@@ -105,7 +105,7 @@ func TestSessionWrappings(t *testing.T) {
 	assert.Contains(t, selLeftJoin.SQL(), "user_id")
 	assert.Contains(t, selLeftJoin.SQL(), "created_at")
 	assert.Contains(t, selLeftJoin.SQL(), "\nFROM sessions\nLEFT OUTER JOIN users ON sessions.user_id = users.id\nWHERE (sessions.user_id = $1 AND sessions.user_id != $2 AND sessions.created_at <= $3 AND sessions.created_at < $4 AND sessions.created_at >= $5 AND sessions.created_at > $6)\nORDER BY created_at DESC\nLIMIT 20 OFFSET 0;")
-	assert.Equal(t, selLeftJoin.Bindings(), []interface{}{"9efbc9ab-7914-426c-8818-7d40b0427c8f", "9efbc9ac-7914-426c-8818-7d40b0427c8f", "2016-06-10", "2016-06-10", "2016-06-09", "2016-06-09"})
+	assert.Equal(t, []interface{}{"9efbc9ab-7914-426c-8818-7d40b0427c8f", "9efbc9ac-7914-426c-8818-7d40b0427c8f", "2016-06-10", "2016-06-10", "2016-06-09", "2016-06-09"}, selLeftJoin.Bindings())
 
 	selRightJoin := qb.Query(sessions.C("id"), sessions.C("user_id"), sessions.C("created_at")).
 		RightJoin(users, sessions.C("user_id"), users.C("id")).
@@ -114,8 +114,8 @@ func TestSessionWrappings(t *testing.T) {
 		Filter(sessions.C("user_id").In("9efbc9ab-7914-426c-8818-7d40b0427c8f")).
 		Statement()
 
-	assert.Equal(t, selRightJoin.SQL(), "SELECT sessions.id, sessions.user_id, sessions.created_at\nFROM sessions\nRIGHT OUTER JOIN users ON sessions.user_id = users.id\nWHERE (sessions.user_id IN ($1))\nORDER BY created_at DESC\nLIMIT 20 OFFSET 0;")
-	assert.Equal(t, selRightJoin.Bindings(), []interface{}{"9efbc9ab-7914-426c-8818-7d40b0427c8f"})
+	assert.Equal(t, "SELECT sessions.id, sessions.user_id, sessions.created_at\nFROM sessions\nRIGHT OUTER JOIN users ON sessions.user_id = users.id\nWHERE (sessions.user_id IN ($1))\nORDER BY created_at DESC\nLIMIT 20 OFFSET 0;", selRightJoin.SQL())
+	assert.Equal(t, []interface{}{"9efbc9ab-7914-426c-8818-7d40b0427c8f"}, selRightJoin.Bindings())
 
 	selCrossJoin := qb.
 		Query(sessions.C("id"), sessions.C("user_id"), sessions.C("created_at")).
@@ -125,16 +125,16 @@ func TestSessionWrappings(t *testing.T) {
 		Filter(sessions.C("user_id").NotIn("9efbc9ab-7914-426c-8818-7d40b0427c8f")).
 		Statement()
 
-	assert.Equal(t, selCrossJoin.SQL(), "SELECT sessions.id, sessions.user_id, sessions.created_at\nFROM sessions\nCROSS JOIN users\nWHERE (sessions.user_id NOT IN ($1))\nORDER BY created_at ASC\nLIMIT 20 OFFSET 0;")
-	assert.Equal(t, selCrossJoin.Bindings(), []interface{}{"9efbc9ab-7914-426c-8818-7d40b0427c8f"})
+	assert.Equal(t, "SELECT sessions.id, sessions.user_id, sessions.created_at\nFROM sessions\nCROSS JOIN users\nWHERE (sessions.user_id NOT IN ($1))\nORDER BY created_at ASC\nLIMIT 20 OFFSET 0;", selCrossJoin.SQL())
+	assert.Equal(t, []interface{}{"9efbc9ab-7914-426c-8818-7d40b0427c8f"}, selCrossJoin.Bindings())
 
 	selLike := qb.
 		Query(users.C("id"), users.C("name")).
 		Filter(users.C("name").Like("%Robert%")).
 		Statement()
 
-	assert.Equal(t, selLike.SQL(), "SELECT id, name\nFROM users\nWHERE (users.name LIKE '%Robert%');")
-	assert.Equal(t, selLike.Bindings(), []interface{}{})
+	assert.Equal(t, "SELECT id, name\nFROM users\nWHERE (users.name LIKE '%Robert%');", selLike.SQL())
+	assert.Equal(t, []interface{}{}, selLike.Bindings())
 
 	selAggCountMinMax := qb.
 		Query(Count(users.C("id")), Max(users.C("name")), Min(users.C("name"))).
@@ -143,16 +143,16 @@ func TestSessionWrappings(t *testing.T) {
 		Having(Sum(users.C("score")), ">", 100).
 		Statement()
 
-	assert.Equal(t, selAggCountMinMax.SQL(), "SELECT COUNT(id), MAX(name), MIN(name)\nFROM users\nGROUP BY name\nHAVING SUM(score) > $1;")
-	assert.Equal(t, selAggCountMinMax.Bindings(), []interface{}{100})
+	assert.Equal(t, "SELECT COUNT(id), MAX(name), MIN(name)\nFROM users\nGROUP BY name\nHAVING SUM(score) > $1;", selAggCountMinMax.SQL())
+	assert.Equal(t, []interface{}{100}, selAggCountMinMax.Bindings())
 
 	selAggAvgSum := qb.
 		Query(Avg(users.C("score")), Sum(users.C("score"))).
 		GroupBy(users.C("id")).
 		Statement()
 
-	assert.Equal(t, selAggAvgSum.SQL(), "SELECT AVG(score), SUM(score)\nFROM \nGROUP BY id;")
-	assert.Equal(t, selAggAvgSum.Bindings(), []interface{}{})
+	assert.Equal(t, "SELECT AVG(score), SUM(score)\nFROM \nGROUP BY id;", selAggAvgSum.SQL())
+	assert.Equal(t, []interface{}{}, selAggAvgSum.Bindings())
 
 	assert.Panics(t, func() {
 		qb.Query()

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -71,9 +71,9 @@ func (suite *SqliteTestSuite) TestSqlite() {
 
 	suite.db.Find(&User{ID: "b6f8bfe3-a830-441a-a097-1777e6bfae95"}).One(&user)
 
-	assert.Equal(suite.T(), user.Email, "jack@nicholson.com")
-	assert.Equal(suite.T(), user.FullName, "Jack Nicholson")
-	assert.Equal(suite.T(), user.Bio.String, "Jack Nicholson, an American actor, producer, screen-writer and director, is a three-time Academy Award winner and twelve-time nominee.")
+	assert.Equal(suite.T(), "jack@nicholson.com", user.Email)
+	assert.Equal(suite.T(), "Jack Nicholson", user.FullName)
+	assert.Equal(suite.T(), "Jack Nicholson, an American actor, producer, screen-writer and director, is a three-time Academy Award winner and twelve-time nominee.", user.Bio.String)
 
 	// select using join
 	sessions := []Session{}
@@ -88,11 +88,11 @@ func (suite *SqliteTestSuite) TestSqlite() {
 		All(&sessions)
 
 	assert.Nil(suite.T(), err)
-	assert.Equal(suite.T(), len(sessions), 1)
+	assert.Equal(suite.T(), 1, len(sessions))
 
-	assert.Equal(suite.T(), sessions[0].ID, 1)
-	assert.Equal(suite.T(), sessions[0].UserID, "b6f8bfe3-a830-441a-a097-1777e6bfae95")
-	assert.Equal(suite.T(), sessions[0].AuthToken, "e4968197-6137-47a4-ba79-690d8c552248")
+	assert.Equal(suite.T(), 1, sessions[0].ID)
+	assert.Equal(suite.T(), "b6f8bfe3-a830-441a-a097-1777e6bfae95", sessions[0].UserID)
+	assert.Equal(suite.T(), "e4968197-6137-47a4-ba79-690d8c552248", sessions[0].AuthToken)
 
 	user.Bio = sql.NullString{String: "nil", Valid: false}
 	suite.db.Add(user)
@@ -101,7 +101,7 @@ func (suite *SqliteTestSuite) TestSqlite() {
 	assert.Nil(suite.T(), err)
 
 	suite.db.Find(&User{ID: "b6f8bfe3-a830-441a-a097-1777e6bfae95"}).One(&user)
-	assert.Equal(suite.T(), user.Bio, sql.NullString{String: "", Valid: false})
+	assert.Equal(suite.T(), sql.NullString{String: "", Valid: false}, user.Bio)
 
 	// delete session
 	suite.db.Delete(&Session{AuthToken: "99e591f8-1025-41ef-a833-6904a0f89a38"})

--- a/statement_test.go
+++ b/statement_test.go
@@ -13,9 +13,9 @@ func TestStatement(t *testing.T) {
 	statement.AddClause("WHERE id = ?")
 	statement.AddBinding(5)
 
-	assert.Equal(t, statement.Clauses(), []string{"SELECT name", "FROM user", "WHERE id = ?"})
-	assert.Equal(t, statement.Bindings(), []interface{}{5})
-	assert.Equal(t, statement.SQL(), "SELECT name\nFROM user\nWHERE id = ?;")
+	assert.Equal(t, []string{"SELECT name", "FROM user", "WHERE id = ?"}, statement.Clauses())
+	assert.Equal(t, []interface{}{5}, statement.Bindings())
+	assert.Equal(t, "SELECT name\nFROM user\nWHERE id = ?;", statement.SQL())
 }
 
 func TestStatementRaw(t *testing.T) {
@@ -27,14 +27,14 @@ func TestStatementRaw(t *testing.T) {
 		WHERE id = ?;
 		`
 	statement.Text(sql)
-	assert.Equal(t, statement.Clauses(), []string{"SELECT name", "FROM user", "WHERE id = ?"})
-	assert.Equal(t, statement.SQL(), "SELECT name\nFROM user\nWHERE id = ?;")
+	assert.Equal(t, []string{"SELECT name", "FROM user", "WHERE id = ?"}, statement.Clauses())
+	assert.Equal(t, "SELECT name\nFROM user\nWHERE id = ?;", statement.SQL())
 }
 
 func TestStatementWithCustomDelimiter(t *testing.T) {
 	statement := Statement()
 
-	assert.Equal(t, statement.SQL(), "")
+	assert.Equal(t, "", statement.SQL())
 
 	statement.SetDelimiter(" ")
 
@@ -44,7 +44,7 @@ func TestStatementWithCustomDelimiter(t *testing.T) {
 	statement.AddClause("WHERE id = ?")
 	statement.AddBinding(5)
 
-	assert.Equal(t, statement.Clauses(), []string{"SELECT name", "FROM user", "WHERE id = ?"})
-	assert.Equal(t, statement.Bindings(), []interface{}{5})
-	assert.Equal(t, statement.SQL(), "SELECT name FROM user WHERE id = ?;")
+	assert.Equal(t, []string{"SELECT name", "FROM user", "WHERE id = ?"}, statement.Clauses())
+	assert.Equal(t, []interface{}{5}, statement.Bindings())
+	assert.Equal(t, "SELECT name FROM user WHERE id = ?;", statement.SQL())
 }

--- a/table_test.go
+++ b/table_test.go
@@ -15,13 +15,13 @@ func (suite *TableTestSuite) TestTableSimpleCreateDrop() {
 	usersTable := Table("users", Column("id", Varchar().Size(40)))
 
 	ddl := usersTable.Create(dialect)
-	assert.Equal(suite.T(), ddl, "CREATE TABLE users (\n\tid VARCHAR(40)\n);")
+	assert.Equal(suite.T(), "CREATE TABLE users (\n\tid VARCHAR(40)\n);", ddl)
 
 	statement := usersTable.Build(dialect)
-	assert.Equal(suite.T(), statement.SQL(), "CREATE TABLE users (\n\tid VARCHAR(40)\n);")
-	assert.Equal(suite.T(), statement.Bindings(), []interface{}{})
+	assert.Equal(suite.T(), "CREATE TABLE users (\n\tid VARCHAR(40)\n);", statement.SQL())
+	assert.Equal(suite.T(), []interface{}{}, statement.Bindings())
 
-	assert.Equal(suite.T(), usersTable.Drop(dialect), "DROP TABLE users;")
+	assert.Equal(suite.T(), "DROP TABLE users;", usersTable.Drop(dialect))
 }
 
 func (suite *TableTestSuite) TestTablePrimaryForeignKey() {
@@ -63,7 +63,7 @@ func (suite *TableTestSuite) TestTablePrimaryKey() {
 		Column("lname", Varchar().Size(40)).PrimaryKey(),
 	)
 
-	assert.Equal(suite.T(), t.PrimaryKeyConstraint.Columns, []string{"fname", "lname"})
+	assert.Equal(suite.T(), []string{"fname", "lname"}, t.PrimaryKeyConstraint.Columns)
 
 	assert.Panics(suite.T(), func() {
 		Table(
@@ -110,14 +110,14 @@ func (suite *TableTestSuite) TestTableIndex() {
 	assert.Contains(suite.T(), ddl, "CREATE INDEX i_email ON users(email)")
 	assert.Contains(suite.T(), ddl, "CREATE INDEX i_id_email ON users(id, email);")
 
-	assert.Equal(suite.T(), usersTable.C("id"), ColumnElem{Name: "id", Type: Varchar().Size(40), Table: "users"})
+	assert.Equal(suite.T(), ColumnElem{Name: "id", Type: Varchar().Size(40), Table: "users"}, usersTable.C("id"))
 	assert.Zero(suite.T(), usersTable.C("nonExisting"))
 }
 
 func (suite *TableTestSuite) TestTableIndexChain() {
 	usersTable := Table("users", Column("id", Varchar().Size(40))).Index("id")
 	ddl := usersTable.Create(NewDialect("mysql"))
-	assert.Equal(suite.T(), ddl, "CREATE TABLE users (\n\tid VARCHAR(40)\n);\nCREATE INDEX i_id ON users(id);")
+	assert.Equal(suite.T(), "CREATE TABLE users (\n\tid VARCHAR(40)\n);\nCREATE INDEX i_id ON users(id);", ddl)
 }
 
 func (suite *TableTestSuite) TestTableStarters() {
@@ -167,24 +167,24 @@ func (suite *TableTestSuite) TestTableStarters() {
 		Where(users.C("id").Eq("5a73ef89-cf0a-4c51-ab8c-cc273ebb3a55")).
 		Build(sqlite)
 
-	assert.Equal(suite.T(), upd.SQL(), "UPDATE users\nSET email = ?\nWHERE users.id = ?;")
-	assert.Equal(suite.T(), upd.Bindings(), []interface{}{"al@pacino.com", "5a73ef89-cf0a-4c51-ab8c-cc273ebb3a55"})
+	assert.Equal(suite.T(), "UPDATE users\nSET email = ?\nWHERE users.id = ?;", upd.SQL())
+	assert.Equal(suite.T(), []interface{}{"al@pacino.com", "5a73ef89-cf0a-4c51-ab8c-cc273ebb3a55"}, upd.Bindings())
 
 	del := users.
 		Delete().
 		Where(users.C("id").Eq("5a73ef89-cf0a-4c51-ab8c-cc273ebb3a55")).
 		Build(sqlite)
 
-	assert.Equal(suite.T(), del.SQL(), "DELETE FROM users\nWHERE users.id = ?;")
-	assert.Equal(suite.T(), del.Bindings(), []interface{}{"5a73ef89-cf0a-4c51-ab8c-cc273ebb3a55"})
+	assert.Equal(suite.T(), "DELETE FROM users\nWHERE users.id = ?;", del.SQL())
+	assert.Equal(suite.T(), []interface{}{"5a73ef89-cf0a-4c51-ab8c-cc273ebb3a55"}, del.Bindings())
 
 	sel := users.
 		Select(users.C("id"), users.C("email")).
 		Where(users.C("id").Eq("5a73ef89-cf0a-4c51-ab8c-cc273ebb3a55")).
 		Build(sqlite)
 
-	assert.Equal(suite.T(), sel.SQL(), "SELECT id, email\nFROM users\nWHERE users.id = ?;")
-	assert.Equal(suite.T(), sel.Bindings(), []interface{}{"5a73ef89-cf0a-4c51-ab8c-cc273ebb3a55"})
+	assert.Equal(suite.T(), "SELECT id, email\nFROM users\nWHERE users.id = ?;", sel.SQL())
+	assert.Equal(suite.T(), []interface{}{"5a73ef89-cf0a-4c51-ab8c-cc273ebb3a55"}, sel.Bindings())
 }
 
 func TestTableTestSuite(t *testing.T) {

--- a/tag_test.go
+++ b/tag_test.go
@@ -7,12 +7,12 @@ import (
 
 func TestTag(t *testing.T) {
 	tag, _ := ParseTag("type:varchar(255);constraints:default(guest),notnull")
-	assert.Equal(t, tag.Type, "varchar(255)")
-	assert.Equal(t, tag.Constraints, []string{"default(guest)", "notnull"})
+	assert.Equal(t, "varchar(255)", tag.Type)
+	assert.Equal(t, []string{"default(guest)", "notnull"}, tag.Constraints)
 
 	tagWithoutConstraint, _ := ParseTag("type:varchar(255);constraints:")
-	assert.Equal(t, tagWithoutConstraint.Type, "varchar(255)")
-	assert.Equal(t, tagWithoutConstraint.Constraints, []string{})
+	assert.Equal(t, "varchar(255)", tagWithoutConstraint.Type)
+	assert.Equal(t, []string{}, tagWithoutConstraint.Constraints)
 
 	tagEmpty, _ := ParseTag("     ")
 	assert.Zero(t, tagEmpty)

--- a/type_test.go
+++ b/type_test.go
@@ -15,25 +15,25 @@ func (suite *TypeTestSuite) TestConstraints() {
 
 	sizeType := Varchar().Size(255).Unique().NotNull().Default("hello")
 
-	assert.Equal(suite.T(), sizeType.String(dialect), "VARCHAR(255) UNIQUE NOT NULL DEFAULT 'hello'")
+	assert.Equal(suite.T(), "VARCHAR(255) UNIQUE NOT NULL DEFAULT 'hello'", sizeType.String(dialect))
 
 	precisionType := Type("FLOAT").Precision(2, 5).Null()
 
-	assert.Equal(suite.T(), precisionType.String(dialect), "FLOAT(2, 5) NULL")
+	assert.Equal(suite.T(), "FLOAT(2, 5) NULL", precisionType.String(dialect))
 
-	assert.Equal(suite.T(), Char().String(dialect), "CHAR")
-	assert.Equal(suite.T(), Varchar().String(dialect), "VARCHAR(255)")
-	assert.Equal(suite.T(), Text().String(dialect), "TEXT")
-	assert.Equal(suite.T(), Int().String(dialect), "INT")
-	assert.Equal(suite.T(), SmallInt().String(dialect), "SMALLINT")
-	assert.Equal(suite.T(), BigInt().String(dialect), "BIGINT")
-	assert.Equal(suite.T(), Numeric().Precision(2, 5).String(dialect), "NUMERIC(2, 5)")
-	assert.Equal(suite.T(), Decimal().String(dialect), "DECIMAL")
-	assert.Equal(suite.T(), Float().String(dialect), "FLOAT")
-	assert.Equal(suite.T(), Boolean().String(dialect), "BOOLEAN")
-	assert.Equal(suite.T(), Timestamp().String(dialect), "TIMESTAMP")
+	assert.Equal(suite.T(), "CHAR", Char().String(dialect))
+	assert.Equal(suite.T(), "VARCHAR(255)", Varchar().String(dialect))
+	assert.Equal(suite.T(), "TEXT", Text().String(dialect))
+	assert.Equal(suite.T(), "INT", Int().String(dialect))
+	assert.Equal(suite.T(), "SMALLINT", SmallInt().String(dialect))
+	assert.Equal(suite.T(), "BIGINT", BigInt().String(dialect))
+	assert.Equal(suite.T(), "NUMERIC(2, 5)", Numeric().Precision(2, 5).String(dialect))
+	assert.Equal(suite.T(), "DECIMAL", Decimal().String(dialect))
+	assert.Equal(suite.T(), "FLOAT", Float().String(dialect))
+	assert.Equal(suite.T(), "BOOLEAN", Boolean().String(dialect))
+	assert.Equal(suite.T(), "TIMESTAMP", Timestamp().String(dialect))
 
-	assert.Equal(suite.T(), Int().Constraint("TEST").String(dialect), "INT TEST")
+	assert.Equal(suite.T(), "INT TEST", Int().Constraint("TEST").String(dialect))
 }
 
 func TestTypeTestSuite(t *testing.T) {
@@ -42,14 +42,14 @@ func TestTypeTestSuite(t *testing.T) {
 
 func (suite *TypeTestSuite) TestUnsigned() {
 	dialect := NewDialect("mysql")
-	assert.Equal(suite.T(), BigInt().Signed().String(dialect), "BIGINT")
-	assert.Equal(suite.T(), BigInt().Unsigned().String(dialect), "BIGINT UNSIGNED")
-	assert.Equal(suite.T(), Numeric().Precision(2, 5).Unsigned().String(dialect), "NUMERIC(2, 5) UNSIGNED")
+	assert.Equal(suite.T(), "BIGINT", BigInt().Signed().String(dialect))
+	assert.Equal(suite.T(), "BIGINT UNSIGNED", BigInt().Unsigned().String(dialect))
+	assert.Equal(suite.T(), "NUMERIC(2, 5) UNSIGNED", Numeric().Precision(2, 5).Unsigned().String(dialect))
 
 	dialect = NewDialect("")
-	assert.Equal(suite.T(), Int().Signed().String(dialect), "INT")
-	assert.Equal(suite.T(), TinyInt().Unsigned().String(dialect), "SMALLINT")
-	assert.Equal(suite.T(), SmallInt().Unsigned().String(dialect), "INT")
-	assert.Equal(suite.T(), Int().Unsigned().String(dialect), "BIGINT")
-	assert.Equal(suite.T(), BigInt().Unsigned().String(dialect), "BIGINT")
+	assert.Equal(suite.T(), "INT", Int().Signed().String(dialect))
+	assert.Equal(suite.T(), "SMALLINT", TinyInt().Unsigned().String(dialect))
+	assert.Equal(suite.T(), "INT", SmallInt().Unsigned().String(dialect))
+	assert.Equal(suite.T(), "BIGINT", Int().Unsigned().String(dialect))
+	assert.Equal(suite.T(), "BIGINT", BigInt().Unsigned().String(dialect))
 }

--- a/update_test.go
+++ b/update_test.go
@@ -28,15 +28,15 @@ func TestUpdate(t *testing.T) {
 		Values(map[string]interface{}{"email": "robert@de.niro"}).
 		Build(sqlite)
 
-	assert.Equal(t, statement.SQL(), "UPDATE users\nSET email = ?;")
-	assert.Equal(t, statement.Bindings(), []interface{}{"robert@de.niro"})
+	assert.Equal(t, "UPDATE users\nSET email = ?;", statement.SQL())
+	assert.Equal(t, []interface{}{"robert@de.niro"}, statement.Bindings())
 
 	statement = Update(users).
 		Values(map[string]interface{}{"email": "robert@de.niro"}).
 		Build(mysql)
 
-	assert.Equal(t, statement.SQL(), "UPDATE `users`\nSET `email` = ?;")
-	assert.Equal(t, statement.Bindings(), []interface{}{"robert@de.niro"})
+	assert.Equal(t, "UPDATE `users`\nSET `email` = ?;", statement.SQL())
+	assert.Equal(t, []interface{}{"robert@de.niro"}, statement.Bindings())
 
 	statement = Update(users).
 		Values(map[string]interface{}{"email": "robert@de.niro"}).
@@ -44,6 +44,6 @@ func TestUpdate(t *testing.T) {
 		Returning(users.C("id"), users.C("email")).
 		Build(postgres)
 
-	assert.Equal(t, statement.SQL(), "UPDATE \"users\"\nSET \"email\" = $1\nWHERE \"users\".\"email\" = $2\nRETURNING \"id\", \"email\";")
-	assert.Equal(t, statement.Bindings(), []interface{}{"robert@de.niro", "al@pacino"})
+	assert.Equal(t, "UPDATE \"users\"\nSET \"email\" = $1\nWHERE \"users\".\"email\" = $2\nRETURNING \"id\", \"email\";", statement.SQL())
+	assert.Equal(t, []interface{}{"robert@de.niro", "al@pacino"}, statement.Bindings())
 }

--- a/upsert_test.go
+++ b/upsert_test.go
@@ -41,7 +41,7 @@ func TestUpsert(t *testing.T) {
 	assert.Contains(t, statement.Bindings(), "9883cf81-3b56-4151-ae4e-3903c5bc436d")
 	assert.Contains(t, statement.Bindings(), "al@pacino.com")
 	assert.Contains(t, statement.Bindings(), now)
-	assert.Equal(t, len(statement.Bindings()), 3)
+	assert.Equal(t, 3, len(statement.Bindings()))
 
 	statement = ups.Build(mysql)
 	assert.Contains(t, statement.SQL(), "INSERT INTO `users`")
@@ -51,7 +51,7 @@ func TestUpsert(t *testing.T) {
 	assert.Contains(t, statement.SQL(), "`id` = ?", "`email` = ?", "`created_at` = ?")
 	assert.Contains(t, statement.Bindings(), "9883cf81-3b56-4151-ae4e-3903c5bc436d")
 	assert.Contains(t, statement.Bindings(), "al@pacino.com")
-	assert.Equal(t, len(statement.Bindings()), 6)
+	assert.Equal(t, 6, len(statement.Bindings()))
 
 	statement = ups.Build(postgres)
 	assert.Contains(t, statement.SQL(), "INSERT INTO \"users\"")
@@ -60,7 +60,7 @@ func TestUpsert(t *testing.T) {
 	assert.Contains(t, statement.SQL(), "ON CONFLICT", "DO UPDATE SET")
 	assert.Contains(t, statement.Bindings(), "9883cf81-3b56-4151-ae4e-3903c5bc436d")
 	assert.Contains(t, statement.Bindings(), "al@pacino.com")
-	assert.Equal(t, len(statement.Bindings()), 6)
+	assert.Equal(t, 6, len(statement.Bindings()))
 
 	statement = Upsert(users).
 		Values(map[string]interface{}{
@@ -78,5 +78,5 @@ func TestUpsert(t *testing.T) {
 	assert.Contains(t, statement.SQL(), "RETURNING \"id\", \"email\";")
 	assert.Contains(t, statement.Bindings(), "9883cf81-3b56-4151-ae4e-3903c5bc436d")
 	assert.Contains(t, statement.Bindings(), "al@pacino.com")
-	assert.Equal(t, len(statement.Bindings()), 4)
+	assert.Equal(t, 4, len(statement.Bindings()))
 }


### PR DESCRIPTION
assert.Equal signature is Equal(test, expected, actual, ...).
This patch put all the Equal args in the right order.