### PR TITLE
Visitor compiler

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -1,9 +1,5 @@
 package qb
 
-import (
-	"fmt"
-)
-
 // Avg function generates "avg(%s)" statement for column
 func Avg(column ColumnElem) AggregateClause {
 	return Aggregate("AVG", column)
@@ -42,11 +38,4 @@ type AggregateClause struct {
 
 func (c AggregateClause) Accept(context *CompilerContext) string {
 	return context.Compiler.VisitAggregate(context, c)
-}
-
-// Build compiles the aggregate clause and returns the sql and bindings
-func (c AggregateClause) Build(dialect Dialect) (string, []interface{}) {
-	bindings := []interface{}{}
-	sql := fmt.Sprintf("%s(%s)", c.fn, dialect.Escape(c.column.Name))
-	return sql, bindings
 }

--- a/aggregate.go
+++ b/aggregate.go
@@ -5,43 +5,47 @@ import (
 )
 
 // Avg function generates "avg(%s)" statement for column
-func Avg(column ColumnElem) AggregateSQLClause {
+func Avg(column ColumnElem) AggregateClause {
 	return Aggregate("AVG", column)
 }
 
 // Count function generates "count(%s)" statement for column
-func Count(column ColumnElem) AggregateSQLClause {
+func Count(column ColumnElem) AggregateClause {
 	return Aggregate("COUNT", column)
 }
 
 // Sum function generates "sum(%s)" statement for column
-func Sum(column ColumnElem) AggregateSQLClause {
+func Sum(column ColumnElem) AggregateClause {
 	return Aggregate("SUM", column)
 }
 
 // Min function generates "min(%s)" statement for column
-func Min(column ColumnElem) AggregateSQLClause {
+func Min(column ColumnElem) AggregateClause {
 	return Aggregate("MIN", column)
 }
 
 // Max function generates "max(%s)" statement for column
-func Max(column ColumnElem) AggregateSQLClause {
+func Max(column ColumnElem) AggregateClause {
 	return Aggregate("MAX", column)
 }
 
 // Aggregate generates a new aggregate clause given function & column
-func Aggregate(fn string, column ColumnElem) AggregateSQLClause {
-	return AggregateSQLClause{fn, column}
+func Aggregate(fn string, column ColumnElem) AggregateClause {
+	return AggregateClause{fn, column}
 }
 
-// AggregateSQLClause is the base struct for building aggregate functions
-type AggregateSQLClause struct {
+// AggregateClause is the base struct for building aggregate functions
+type AggregateClause struct {
 	fn     string
 	column ColumnElem
 }
 
+func (c AggregateClause) Accept(context *CompilerContext) string {
+	return context.Compiler.VisitAggregate(context, c)
+}
+
 // Build compiles the aggregate clause and returns the sql and bindings
-func (c AggregateSQLClause) Build(dialect Dialect) (string, []interface{}) {
+func (c AggregateClause) Build(dialect Dialect) (string, []interface{}) {
 	bindings := []interface{}{}
 	sql := fmt.Sprintf("%s(%s)", c.fn, dialect.Escape(c.column.Name))
 	return sql, bindings

--- a/aggregate.go
+++ b/aggregate.go
@@ -5,43 +5,43 @@ import (
 )
 
 // Avg function generates "avg(%s)" statement for column
-func Avg(column ColumnElem) AggregateClause {
+func Avg(column ColumnElem) AggregateSQLClause {
 	return Aggregate("AVG", column)
 }
 
 // Count function generates "count(%s)" statement for column
-func Count(column ColumnElem) AggregateClause {
+func Count(column ColumnElem) AggregateSQLClause {
 	return Aggregate("COUNT", column)
 }
 
 // Sum function generates "sum(%s)" statement for column
-func Sum(column ColumnElem) AggregateClause {
+func Sum(column ColumnElem) AggregateSQLClause {
 	return Aggregate("SUM", column)
 }
 
 // Min function generates "min(%s)" statement for column
-func Min(column ColumnElem) AggregateClause {
+func Min(column ColumnElem) AggregateSQLClause {
 	return Aggregate("MIN", column)
 }
 
 // Max function generates "max(%s)" statement for column
-func Max(column ColumnElem) AggregateClause {
+func Max(column ColumnElem) AggregateSQLClause {
 	return Aggregate("MAX", column)
 }
 
 // Aggregate generates a new aggregate clause given function & column
-func Aggregate(fn string, column ColumnElem) AggregateClause {
-	return AggregateClause{fn, column}
+func Aggregate(fn string, column ColumnElem) AggregateSQLClause {
+	return AggregateSQLClause{fn, column}
 }
 
-// AggregateClause is the base struct for building aggregate functions
-type AggregateClause struct {
+// AggregateSQLClause is the base struct for building aggregate functions
+type AggregateSQLClause struct {
 	fn     string
 	column ColumnElem
 }
 
 // Build compiles the aggregate clause and returns the sql and bindings
-func (c AggregateClause) Build(dialect Dialect) (string, []interface{}) {
+func (c AggregateSQLClause) Build(dialect Dialect) (string, []interface{}) {
 	bindings := []interface{}{}
 	sql := fmt.Sprintf("%s(%s)", c.fn, dialect.Escape(c.column.Name))
 	return sql, bindings

--- a/clause.go
+++ b/clause.go
@@ -8,16 +8,16 @@ type Compiles interface {
 	Build(dialect Dialect) (string, []interface{})
 }
 
-// Clause is the key interface for any sql clause
-type Clause interface {
+// SQLClause is the key interface for any sql clause
+type SQLClause interface {
 	Compiles
 	// String returns the dialect agnostic sql clause and bindings.
 	// It returns :varname as placeholders instead of $n or ?.
 	//String() (string, []interface{})
 }
 
-// TableClause is the common interface for ddl generators such as Column(), PrimaryKey(), ForeignKey().Ref(), etc.
-type TableClause interface {
+// TableSQLClause is the common interface for ddl generators such as Column(), PrimaryKey(), ForeignKey().Ref(), etc.
+type TableSQLClause interface {
 	// String takes the dialect and returns the ddl as an sql string
 	String(dialect Dialect) string
 }

--- a/clause.go
+++ b/clause.go
@@ -4,22 +4,6 @@ type Clause interface {
 	Accept(context *CompilerContext) string
 }
 
-// Compiles is the standard interface for any compilable sql clause
-// Compiling means to post process any sql clauses if needed such as escaping, putting placeholders, etc.
-type Compiles interface {
-	// Build is the key function of any sql clause
-	// It returns sql as string and bindings as []interface{}
-	Build(dialect Dialect) (string, []interface{})
-}
-
-// SQLClause is the key interface for any sql clause
-type SQLClause interface {
-	Compiles
-	// String returns the dialect agnostic sql clause and bindings.
-	// It returns :varname as placeholders instead of $n or ?.
-	//String() (string, []interface{})
-}
-
 // TableSQLClause is the common interface for ddl generators such as Column(), PrimaryKey(), ForeignKey().Ref(), etc.
 type TableSQLClause interface {
 	// String takes the dialect and returns the ddl as an sql string

--- a/clause.go
+++ b/clause.go
@@ -1,5 +1,9 @@
 package qb
 
+type Clause interface {
+	Accept(context *CompilerContext) string
+}
+
 // Compiles is the standard interface for any compilable sql clause
 // Compiling means to post process any sql clauses if needed such as escaping, putting placeholders, etc.
 type Compiles interface {

--- a/clause.go
+++ b/clause.go
@@ -1,5 +1,6 @@
 package qb
 
+// Clause is the common interface of any SQL expression
 type Clause interface {
 	Accept(context *CompilerContext) string
 }

--- a/clauses.go
+++ b/clauses.go
@@ -1,5 +1,9 @@
 package qb
 
+import (
+	"reflect"
+)
+
 // SQLText returns a raw SQL clause
 func SQLText(text string) TextClause {
 	return TextClause{Text: text}
@@ -13,4 +17,85 @@ type TextClause struct {
 // Accept calls the compiler VisitText method
 func (c TextClause) Accept(context *CompilerContext) string {
 	return context.Compiler.VisitText(context, c)
+}
+
+// List returns a list-of-clauses clause
+func List(clauses ...Clause) ListClause {
+	return ListClause{
+		Clauses: clauses,
+	}
+}
+
+// ListClause is a list of clause elements (for IN operator for example)
+type ListClause struct {
+	Clauses []Clause
+}
+
+// Accept calls the compiler VisitList method
+func (c ListClause) Accept(context *CompilerContext) string {
+	return context.Compiler.VisitList(context, c)
+}
+
+// Bind a value
+func Bind(value interface{}) BindClause {
+	return BindClause{
+		Value: value,
+	}
+}
+
+// BindClause binds a value to a placeholder
+type BindClause struct {
+	Value interface{}
+}
+
+// Accept calls the compiler VisitBind method
+func (c BindClause) Accept(context *CompilerContext) string {
+	return context.Compiler.VisitBind(context, c)
+}
+
+// GetClauseFrom returns the value if already a Clause, or make one
+// if it is a scalar value
+func GetClauseFrom(value interface{}) Clause {
+	if clause, ok := value.(Clause); ok {
+		return clause
+	}
+	// For now we assume any non-clause is a Value:
+	return Bind(value)
+}
+
+// GetListFrom returns a list clause from any list
+//
+// if 'any' is a Clause, it is wrapped into a ListClause unless it is
+// a ListClause, in which case it is returned as-is
+//
+// if 'any' is not a list, it is wrapped as a clause, and returned a the
+// only item of a new ListClause
+//
+// if 'any' is a list:
+//   if len>1 each item is converted to a clause if not already one.
+//   if len=1, the function is recursively called on it. This allow to use
+//   this function on a variadic arg where a single list clause is passed.
+//
+func GetListFrom(any interface{}) Clause {
+	if clause, ok := any.(Clause); ok {
+		if _, isList := clause.(ListClause); isList {
+			return clause
+		}
+		return List(clause)
+	}
+
+	v := reflect.ValueOf(any)
+	switch kind := v.Kind(); kind {
+	case reflect.Array, reflect.Slice:
+		if v.Len() == 1 {
+			return GetListFrom(v.Index(0).Interface())
+		}
+		var clauses []Clause
+		for i := 0; i != v.Len(); i++ {
+			clauses = append(clauses, GetClauseFrom(v.Index(i).Interface()))
+		}
+		return List(clauses...)
+	default:
+		return List(GetClauseFrom(any))
+	}
 }

--- a/clauses.go
+++ b/clauses.go
@@ -1,0 +1,16 @@
+package qb
+
+// SQLText returns a raw SQL clause
+func SQLText(text string) TextClause {
+	return TextClause{Text: text}
+}
+
+// TextClause is a raw SQL clause
+type TextClause struct {
+	Text string
+}
+
+// Accept calls the compiler VisitText method
+func (c TextClause) Accept(context *CompilerContext) string {
+	return context.Compiler.VisitText(context, c)
+}

--- a/clauses.go
+++ b/clauses.go
@@ -99,3 +99,30 @@ func GetListFrom(any interface{}) Clause {
 		return List(GetClauseFrom(any))
 	}
 }
+
+// Exists returns a EXISTS clause
+func Exists(sel SelectStmt) ExistsClause {
+	return ExistsClause{
+		Select: sel,
+		Not:    false,
+	}
+}
+
+// NotExists returns a NOT EXISTS clause
+func NotExists(sel SelectStmt) ExistsClause {
+	return ExistsClause{
+		Select: sel,
+		Not:    true,
+	}
+}
+
+// ExistsClause is a EXISTS clause
+type ExistsClause struct {
+	Select SelectStmt
+	Not    bool
+}
+
+// Accept calls compiler VisitExists methos
+func (c ExistsClause) Accept(context *CompilerContext) string {
+	return context.Compiler.VisitExists(context, c)
+}

--- a/clauses_test.go
+++ b/clauses_test.go
@@ -1,0 +1,11 @@
+package qb
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSQLText(t *testing.T) {
+	text := SQLText("1")
+	assert.Equal(t, "1", text.Text)
+}

--- a/clauses_test.go
+++ b/clauses_test.go
@@ -46,3 +46,15 @@ func TestGetListFrom(t *testing.T) {
 	assert.Equal(t, 2, l.Clauses[0].(BindClause).Value)
 	assert.Equal(t, 4, l.Clauses[1].(BindClause).Value)
 }
+
+func TestExists(t *testing.T) {
+	s := Select()
+
+	e := Exists(s)
+	assert.False(t, e.Not)
+	assert.Equal(t, s, e.Select)
+
+	ne := NotExists(s)
+	assert.True(t, ne.Not)
+	assert.Equal(t, s, ne.Select)
+}

--- a/clauses_test.go
+++ b/clauses_test.go
@@ -9,3 +9,40 @@ func TestSQLText(t *testing.T) {
 	text := SQLText("1")
 	assert.Equal(t, "1", text.Text)
 }
+
+func TestGetClauseFrom(t *testing.T) {
+	var c Clause
+	c = SQLText("1")
+	assert.Equal(t, c, GetClauseFrom(c))
+
+	c = GetClauseFrom(2)
+	b, ok := c.(BindClause)
+	assert.True(t, ok, "Should have returned a BindClause")
+	assert.Equal(t, 2, b.Value)
+}
+
+func TestGetListFrom(t *testing.T) {
+	var c Clause
+	c = ListClause{}
+	assert.Equal(t, c, GetListFrom(c))
+
+	text := SQLText("SOME SQL")
+	c = GetListFrom(text)
+	l, ok := c.(ListClause)
+	assert.True(t, ok, "Should have returned a ListClause")
+	assert.Equal(t, 1, len(l.Clauses))
+	assert.Equal(t, text, l.Clauses[0])
+
+	c = GetListFrom([]int{2})
+	l, ok = c.(ListClause)
+	assert.True(t, ok, "Should have returned a ListClause")
+	assert.Equal(t, 1, len(l.Clauses))
+	assert.Equal(t, 2, l.Clauses[0].(BindClause).Value)
+
+	c = GetListFrom([]interface{}{2, Bind(4)})
+	l, ok = c.(ListClause)
+	assert.True(t, ok, "Should have returned a ListClause")
+	assert.Equal(t, 2, len(l.Clauses))
+	assert.Equal(t, 2, l.Clauses[0].(BindClause).Value)
+	assert.Equal(t, 4, l.Clauses[1].(BindClause).Value)
+}

--- a/column.go
+++ b/column.go
@@ -43,7 +43,7 @@ func (c ColumnElem) PrimaryKey() ColumnElem {
 }
 
 // String returns the column element as an sql clause
-// It satisfies the TableClause interface
+// It satisfies the TableSQLClause interface
 func (c ColumnElem) String(dialect Dialect) string {
 	colSpec := ""
 	if c.Options.AutoIncrement {
@@ -64,7 +64,7 @@ func (c ColumnElem) String(dialect Dialect) string {
 }
 
 // Build compiles the column element and returns sql, bindings
-// It satisfies the Clause interface
+// It satisfies the SQLClause interface
 func (c ColumnElem) Build(dialect Dialect) (string, []interface{}) {
 	return dialect.Escape(c.Name), []interface{}{}
 }
@@ -105,46 +105,46 @@ func (c ColumnElem) Constraint(name string) ColumnElem {
 // conditional wrappers
 
 // Like wraps the Like(col ColumnElem, pattern string)
-func (c ColumnElem) Like(pattern string) Clause {
+func (c ColumnElem) Like(pattern string) SQLClause {
 	return Like(c, pattern)
 }
 
 // NotIn wraps the NotIn(col ColumnElem, values ...interface{})
-func (c ColumnElem) NotIn(values ...interface{}) Clause {
+func (c ColumnElem) NotIn(values ...interface{}) SQLClause {
 	return NotIn(c, values...)
 }
 
 // In wraps the In(col ColumnElem, values ...interface{})
-func (c ColumnElem) In(values ...interface{}) Clause {
+func (c ColumnElem) In(values ...interface{}) SQLClause {
 	return In(c, values...)
 }
 
 // NotEq wraps the NotEq(col ColumnElem, value interface{})
-func (c ColumnElem) NotEq(value interface{}) Clause {
+func (c ColumnElem) NotEq(value interface{}) SQLClause {
 	return NotEq(c, value)
 }
 
 // Eq wraps the Eq(col ColumnElem, value interface{})
-func (c ColumnElem) Eq(value interface{}) Clause {
+func (c ColumnElem) Eq(value interface{}) SQLClause {
 	return Eq(c, value)
 }
 
 // Gt wraps the Gt(col ColumnElem, value interface{})
-func (c ColumnElem) Gt(value interface{}) Clause {
+func (c ColumnElem) Gt(value interface{}) SQLClause {
 	return Gt(c, value)
 }
 
 // Lt wraps the Lt(col ColumnElem, value interface{})
-func (c ColumnElem) Lt(value interface{}) Clause {
+func (c ColumnElem) Lt(value interface{}) SQLClause {
 	return Lt(c, value)
 }
 
 // Gte wraps the Gte(col ColumnElem, value interface{})
-func (c ColumnElem) Gte(value interface{}) Clause {
+func (c ColumnElem) Gte(value interface{}) SQLClause {
 	return Gte(c, value)
 }
 
 // Lte wraps the Lte(col ColumnElem, value interface{})
-func (c ColumnElem) Lte(value interface{}) Clause {
+func (c ColumnElem) Lte(value interface{}) SQLClause {
 	return Lte(c, value)
 }

--- a/column.go
+++ b/column.go
@@ -103,46 +103,46 @@ func (c ColumnElem) Constraint(name string) ColumnElem {
 // conditional wrappers
 
 // Like wraps the Like(col ColumnElem, pattern string)
-func (c ColumnElem) Like(pattern string) SQLClause {
+func (c ColumnElem) Like(pattern string) Clause {
 	return Like(c, pattern)
 }
 
 // NotIn wraps the NotIn(col ColumnElem, values ...interface{})
-func (c ColumnElem) NotIn(values ...interface{}) SQLClause {
+func (c ColumnElem) NotIn(values ...interface{}) Clause {
 	return NotIn(c, values...)
 }
 
 // In wraps the In(col ColumnElem, values ...interface{})
-func (c ColumnElem) In(values ...interface{}) SQLClause {
+func (c ColumnElem) In(values ...interface{}) Clause {
 	return In(c, values...)
 }
 
 // NotEq wraps the NotEq(col ColumnElem, value interface{})
-func (c ColumnElem) NotEq(value interface{}) SQLClause {
+func (c ColumnElem) NotEq(value interface{}) Clause {
 	return NotEq(c, value)
 }
 
 // Eq wraps the Eq(col ColumnElem, value interface{})
-func (c ColumnElem) Eq(value interface{}) SQLClause {
+func (c ColumnElem) Eq(value interface{}) Clause {
 	return Eq(c, value)
 }
 
 // Gt wraps the Gt(col ColumnElem, value interface{})
-func (c ColumnElem) Gt(value interface{}) SQLClause {
+func (c ColumnElem) Gt(value interface{}) Clause {
 	return Gt(c, value)
 }
 
 // Lt wraps the Lt(col ColumnElem, value interface{})
-func (c ColumnElem) Lt(value interface{}) SQLClause {
+func (c ColumnElem) Lt(value interface{}) Clause {
 	return Lt(c, value)
 }
 
 // Gte wraps the Gte(col ColumnElem, value interface{})
-func (c ColumnElem) Gte(value interface{}) SQLClause {
+func (c ColumnElem) Gte(value interface{}) Clause {
 	return Gte(c, value)
 }
 
 // Lte wraps the Lte(col ColumnElem, value interface{})
-func (c ColumnElem) Lte(value interface{}) SQLClause {
+func (c ColumnElem) Lte(value interface{}) Clause {
 	return Lte(c, value)
 }

--- a/column.go
+++ b/column.go
@@ -63,10 +63,8 @@ func (c ColumnElem) String(dialect Dialect) string {
 	return res
 }
 
-// Build compiles the column element and returns sql, bindings
-// It satisfies the SQLClause interface
-func (c ColumnElem) Build(dialect Dialect) (string, []interface{}) {
-	return dialect.Escape(c.Name), []interface{}{}
+func (c ColumnElem) Accept(context *CompilerContext) string {
+	return context.Compiler.VisitColumn(context, c)
 }
 
 // constraints setters

--- a/column_test.go
+++ b/column_test.go
@@ -39,12 +39,12 @@ func TestColumn(t *testing.T) {
 
 	var sql string
 
-	sql, _ = col.Build(sqlite)
+	sql = col.Accept(NewCompilerContext(sqlite.GetCompiler()))
 	assert.Equal(t, "id", sql)
 
-	sql, _ = col.Build(mysql)
+	sql = col.Accept(NewCompilerContext(mysql.GetCompiler()))
 	assert.Equal(t, "`id`", sql)
 
-	sql, _ = col.Build(postgres)
+	sql = col.Accept(NewCompilerContext(postgres.GetCompiler()))
 	assert.Equal(t, "\"id\"", sql)
 }

--- a/column_test.go
+++ b/column_test.go
@@ -39,12 +39,12 @@ func TestColumn(t *testing.T) {
 
 	var sql string
 
-	sql = col.Accept(NewCompilerContext(sqlite.GetCompiler()))
+	sql = col.Accept(NewCompilerContext(sqlite))
 	assert.Equal(t, "id", sql)
 
-	sql = col.Accept(NewCompilerContext(mysql.GetCompiler()))
+	sql = col.Accept(NewCompilerContext(mysql))
 	assert.Equal(t, "`id`", sql)
 
-	sql = col.Accept(NewCompilerContext(postgres.GetCompiler()))
+	sql = col.Accept(NewCompilerContext(postgres))
 	assert.Equal(t, "\"id\"", sql)
 }

--- a/combiner.go
+++ b/combiner.go
@@ -6,7 +6,7 @@ import (
 )
 
 // buildCombiners generates and or statements and join them appropriately
-func buildCombiners(dialect Dialect, combiner string, clauses []Clause) (string, []interface{}) {
+func buildCombiners(dialect Dialect, combiner string, clauses []SQLClause) (string, []interface{}) {
 	sqls := []string{}
 	bindings := []interface{}{}
 	for _, c := range clauses {
@@ -18,34 +18,34 @@ func buildCombiners(dialect Dialect, combiner string, clauses []Clause) (string,
 	return fmt.Sprintf("(%s)", strings.Join(sqls, fmt.Sprintf(" %s ", combiner))), bindings
 }
 
-// And generates an AndClause given conditional clauses
-func And(clauses ...Clause) AndClause {
-	return AndClause{clauses}
+// And generates an AndSQLClause given conditional clauses
+func And(clauses ...SQLClause) AndSQLClause {
+	return AndSQLClause{clauses}
 }
 
-// AndClause is the base struct to keep and within the where clause
-// It satisfies the Clause interface
-type AndClause struct {
-	clauses []Clause
+// AndSQLClause is the base struct to keep and within the where clause
+// It satisfies the SQLClause interface
+type AndSQLClause struct {
+	clauses []SQLClause
 }
 
 // Build compiles the and clause, joins the sql, returns sql and bindings
-func (c AndClause) Build(dialect Dialect) (string, []interface{}) {
+func (c AndSQLClause) Build(dialect Dialect) (string, []interface{}) {
 	return buildCombiners(dialect, "AND", c.clauses)
 }
 
-// Or generates an OrClause given conditional clauses
-func Or(clauses ...Clause) OrClause {
-	return OrClause{clauses}
+// Or generates an OrSQLClause given conditional clauses
+func Or(clauses ...SQLClause) OrSQLClause {
+	return OrSQLClause{clauses}
 }
 
-// OrClause is the base struct to keep or within the where clause
-// It satisfies the Clause interface
-type OrClause struct {
-	clauses []Clause
+// OrSQLClause is the base struct to keep or within the where clause
+// It satisfies the SQLClause interface
+type OrSQLClause struct {
+	clauses []SQLClause
 }
 
 // Build compiles the or clause, joins the sql, returns sql and bindings
-func (c OrClause) Build(dialect Dialect) (string, []interface{}) {
+func (c OrSQLClause) Build(dialect Dialect) (string, []interface{}) {
 	return buildCombiners(dialect, "OR", c.clauses)
 }

--- a/combiner.go
+++ b/combiner.go
@@ -1,51 +1,22 @@
 package qb
 
-import (
-	"fmt"
-	"strings"
-)
-
-// buildCombiners generates and or statements and join them appropriately
-func buildCombiners(dialect Dialect, combiner string, clauses []SQLClause) (string, []interface{}) {
-	sqls := []string{}
-	bindings := []interface{}{}
-	for _, c := range clauses {
-		sql, values := c.Build(dialect)
-		sqls = append(sqls, sql)
-		bindings = append(bindings, values...)
-	}
-
-	return fmt.Sprintf("(%s)", strings.Join(sqls, fmt.Sprintf(" %s ", combiner))), bindings
+// And generates an AndClause given conditional clauses
+func And(clauses ...Clause) CombinerClause {
+	return CombinerClause{"AND", clauses}
 }
 
-// And generates an AndSQLClause given conditional clauses
-func And(clauses ...SQLClause) AndSQLClause {
-	return AndSQLClause{clauses}
+// Or generates an AndClause given conditional clauses
+func Or(clauses ...Clause) CombinerClause {
+	return CombinerClause{"OR", clauses}
 }
 
-// AndSQLClause is the base struct to keep and within the where clause
-// It satisfies the SQLClause interface
-type AndSQLClause struct {
-	clauses []SQLClause
+// CombinerClause is for OR and AND clauses
+type CombinerClause struct {
+	operator string
+	clauses  []Clause
 }
 
-// Build compiles the and clause, joins the sql, returns sql and bindings
-func (c AndSQLClause) Build(dialect Dialect) (string, []interface{}) {
-	return buildCombiners(dialect, "AND", c.clauses)
-}
-
-// Or generates an OrSQLClause given conditional clauses
-func Or(clauses ...SQLClause) OrSQLClause {
-	return OrSQLClause{clauses}
-}
-
-// OrSQLClause is the base struct to keep or within the where clause
-// It satisfies the SQLClause interface
-type OrSQLClause struct {
-	clauses []SQLClause
-}
-
-// Build compiles the or clause, joins the sql, returns sql and bindings
-func (c OrSQLClause) Build(dialect Dialect) (string, []interface{}) {
-	return buildCombiners(dialect, "OR", c.clauses)
+// Accept calls the compiler VisitCombiner entry point
+func (c CombinerClause) Accept(context *CompilerContext) string {
+	return context.Compiler.VisitCombiner(context, c)
 }

--- a/combiner_test.go
+++ b/combiner_test.go
@@ -22,34 +22,39 @@ func TestCombiners(t *testing.T) {
 	or := Or(Eq(email, "al@pacino.com"), NotEq(id, 1))
 
 	var sql string
-	var bindings []interface{}
-	sql, bindings = and.Build(sqlite)
+	ctx := NewCompilerContext(sqlite)
+	sql = and.Accept(ctx)
 
 	assert.Equal(t, "(email = ? AND id != ?)", sql)
-	assert.Equal(t, []interface{}{"al@pacino.com", 1}, bindings)
+	assert.Equal(t, []interface{}{"al@pacino.com", 1}, ctx.Binds)
 
-	sql, bindings = and.Build(mysql)
+	ctx = NewCompilerContext(mysql)
+	sql = and.Accept(ctx)
 
 	assert.Equal(t, "(`email` = ? AND `id` != ?)", sql)
-	assert.Equal(t, []interface{}{"al@pacino.com", 1}, bindings)
+	assert.Equal(t, []interface{}{"al@pacino.com", 1}, ctx.Binds)
 
-	sql, bindings = and.Build(postgres)
+	ctx = NewCompilerContext(postgres)
+	sql = and.Accept(ctx)
 
 	assert.Equal(t, "(\"email\" = $1 AND \"id\" != $2)", sql)
-	assert.Equal(t, []interface{}{"al@pacino.com", 1}, bindings)
+	assert.Equal(t, []interface{}{"al@pacino.com", 1}, ctx.Binds)
 
-	sql, bindings = or.Build(sqlite)
+	ctx = NewCompilerContext(sqlite)
+	sql = or.Accept(ctx)
 
 	assert.Equal(t, "(email = ? OR id != ?)", sql)
-	assert.Equal(t, []interface{}{"al@pacino.com", 1}, bindings)
+	assert.Equal(t, []interface{}{"al@pacino.com", 1}, ctx.Binds)
 
-	sql, bindings = or.Build(mysql)
+	ctx = NewCompilerContext(mysql)
+	sql = or.Accept(ctx)
 
 	assert.Equal(t, "(`email` = ? OR `id` != ?)", sql)
-	assert.Equal(t, []interface{}{"al@pacino.com", 1}, bindings)
+	assert.Equal(t, []interface{}{"al@pacino.com", 1}, ctx.Binds)
 
-	sql, bindings = or.Build(postgres)
+	ctx = NewCompilerContext(postgres)
+	sql = or.Accept(ctx)
 
 	assert.Equal(t, "(\"email\" = $3 OR \"id\" != $4)", sql)
-	assert.Equal(t, []interface{}{"al@pacino.com", 1}, bindings)
+	assert.Equal(t, []interface{}{"al@pacino.com", 1}, ctx.Binds)
 }

--- a/compiler.go
+++ b/compiler.go
@@ -35,6 +35,7 @@ type Compiler interface {
 	VisitOrderBy(*CompilerContext, OrderByClause) string
 	VisitSelect(*CompilerContext, SelectStmt) string
 	VisitUpdate(*CompilerContext, UpdateStmt) string
+	VisitUpsert(*CompilerContext, UpsertStmt) string
 	VisitWhere(*CompilerContext, WhereClause) string
 }
 
@@ -262,6 +263,10 @@ func (c SQLCompiler) VisitUpdate(context *CompilerContext, update UpdateStmt) st
 	}
 
 	return sql
+}
+
+func (c SQLCompiler) VisitUpsert(context *CompilerContext, upsert UpsertStmt) string {
+	panic("Upsert is not Implemented in this compiler")
 }
 
 func (c SQLCompiler) VisitWhere(context *CompilerContext, where WhereClause) string {

--- a/compiler.go
+++ b/compiler.go
@@ -25,10 +25,13 @@ type CompilerContext struct {
 type Compiler interface {
 	VisitAggregate(*CompilerContext, AggregateClause) string
 	VisitColumn(*CompilerContext, ColumnElem) string
+	VisitCombiner(*CompilerContext, CombinerClause) string
+	VisitCondition(*CompilerContext, Conditional) string
 	VisitHaving(*CompilerContext, HavingClause) string
 	VisitJoin(*CompilerContext, JoinClause) string
 	VisitLabel(*CompilerContext, string) string
 	VisitOrderBy(*CompilerContext, OrderByClause) string
+	VisitWhere(*CompilerContext, WhereClause) string
 }
 
 type SQLCompiler struct {
@@ -45,6 +48,36 @@ func (c SQLCompiler) VisitColumn(context *CompilerContext, column ColumnElem) st
 		sql += c.Dialect.Escape(column.Table) + "."
 	}
 	sql += c.Dialect.Escape(column.Name)
+	return sql
+}
+
+func (c SQLCompiler) VisitCombiner(context *CompilerContext, combiner CombinerClause) string {
+	sqls := []string{}
+	for _, c := range combiner.clauses {
+		sql := c.Accept(context)
+		sqls = append(sqls, sql)
+	}
+
+	return fmt.Sprintf("(%s)", strings.Join(sqls, fmt.Sprintf(" %s ", combiner.operator)))
+}
+
+func (c SQLCompiler) VisitCondition(context *CompilerContext, condition Conditional) string {
+	var sql string
+	key := condition.Col.Accept(context)
+
+	switch condition.Op {
+	case "IN":
+		sql = fmt.Sprintf("%s %s (%s)", key, condition.Op, strings.Join(context.Dialect.Placeholders(condition.Values...), ", "))
+		context.Binds = append(context.Binds, condition.Values...)
+	case "NOT IN":
+		sql = fmt.Sprintf("%s %s (%s)", key, condition.Op, strings.Join(context.Dialect.Placeholders(condition.Values...), ", "))
+		context.Binds = append(context.Binds, condition.Values...)
+	case "LIKE":
+		sql = fmt.Sprintf("%s %s '%s'", key, condition.Op, condition.Values[0])
+	default:
+		sql = fmt.Sprintf("%s %s %s", key, condition.Op, context.Dialect.Placeholder())
+		context.Binds = append(context.Binds, condition.Values...)
+	}
 	return sql
 }
 
@@ -78,4 +111,8 @@ func (c SQLCompiler) VisitOrderBy(context *CompilerContext, orderBy OrderByClaus
 	}
 
 	return fmt.Sprintf("ORDER BY %s %s", strings.Join(cols, ", "), orderBy.t)
+}
+
+func (c SQLCompiler) VisitWhere(context *CompilerContext, where WhereClause) string {
+	return fmt.Sprintf("WHERE %s", where.clause.Accept(context))
 }

--- a/compiler.go
+++ b/compiler.go
@@ -36,6 +36,7 @@ type Compiler interface {
 	VisitOrderBy(*CompilerContext, OrderByClause) string
 	VisitSelect(*CompilerContext, SelectStmt) string
 	VisitTable(*CompilerContext, TableElem) string
+	VisitText(*CompilerContext, TextClause) string
 	VisitUpdate(*CompilerContext, UpdateStmt) string
 	VisitUpsert(*CompilerContext, UpsertStmt) string
 	VisitWhere(*CompilerContext, WhereClause) string
@@ -237,6 +238,10 @@ func (c SQLCompiler) VisitSelect(context *CompilerContext, select_ SelectStmt) s
 
 func (SQLCompiler) VisitTable(context *CompilerContext, table TableElem) string {
 	return context.Compiler.VisitLabel(context, table.Name)
+}
+
+func (SQLCompiler) VisitText(context *CompilerContext, text TextClause) string {
+	return text.Text
 }
 
 func (c SQLCompiler) VisitUpdate(context *CompilerContext, update UpdateStmt) string {

--- a/compiler.go
+++ b/compiler.go
@@ -34,6 +34,7 @@ type Compiler interface {
 	VisitLabel(*CompilerContext, string) string
 	VisitOrderBy(*CompilerContext, OrderByClause) string
 	VisitSelect(*CompilerContext, SelectStmt) string
+	VisitTable(*CompilerContext, TableElem) string
 	VisitUpdate(*CompilerContext, UpdateStmt) string
 	VisitUpsert(*CompilerContext, UpsertStmt) string
 	VisitWhere(*CompilerContext, WhereClause) string
@@ -87,8 +88,7 @@ func (c SQLCompiler) VisitCondition(context *CompilerContext, condition Conditio
 }
 
 func (c SQLCompiler) VisitDelete(context *CompilerContext, delete DeleteStmt) string {
-	sql := "DELETE FROM "
-	sql += context.Compiler.VisitLabel(context, delete.table.Name)
+	sql := "DELETE FROM " + delete.table.Accept(context)
 
 	if delete.where != nil {
 		sql += "\n" + delete.where.Accept(context)
@@ -129,7 +129,7 @@ func (c SQLCompiler) VisitInsert(context *CompilerContext, insert InsertStmt) st
 
 	sql := fmt.Sprintf(
 		"INSERT INTO %s(%s)\nVALUES(%s)",
-		context.Compiler.VisitLabel(context, insert.table.Name),
+		insert.table.Accept(context),
 		strings.Join(colNames, ", "),
 		strings.Join(placeholders, ", "),
 	)
@@ -192,7 +192,7 @@ func (c SQLCompiler) VisitSelect(context *CompilerContext, select_ SelectStmt) s
 	addLine(fmt.Sprintf("SELECT %s", strings.Join(columns, ", ")))
 
 	// from
-	addLine(fmt.Sprintf("FROM %s", context.Dialect.Escape(select_.from.Name)))
+	addLine(fmt.Sprintf("FROM %s", select_.from.Accept(context)))
 
 	// joins
 	for _, j := range select_.joins {
@@ -232,8 +232,12 @@ func (c SQLCompiler) VisitSelect(context *CompilerContext, select_ SelectStmt) s
 	return strings.Join(lines, "\n")
 }
 
+func (SQLCompiler) VisitTable(context *CompilerContext, table TableElem) string {
+	return context.Compiler.VisitLabel(context, table.Name)
+}
+
 func (c SQLCompiler) VisitUpdate(context *CompilerContext, update UpdateStmt) string {
-	sql := "UPDATE " + context.Compiler.VisitLabel(context, update.table.Name)
+	sql := "UPDATE " + update.table.Accept(context)
 
 	var sets []string
 	for k, v := range update.values {

--- a/compiler.go
+++ b/compiler.go
@@ -150,7 +150,8 @@ func (c SQLCompiler) VisitInsert(context *CompilerContext, insert InsertStmt) st
 
 func (c SQLCompiler) VisitJoin(context *CompilerContext, join JoinClause) string {
 	sql := fmt.Sprintf(
-		"%s %s",
+		"%s\n%s %s",
+		join.left.Accept(context),
 		join.joinType,
 		join.right.Accept(context),
 	)
@@ -179,9 +180,7 @@ func (c SQLCompiler) VisitSelect(context *CompilerContext, select_ SelectStmt) s
 	addLine := func(s string) {
 		lines = append(lines, s)
 	}
-	if len(select_.joins) == 0 {
-		context.DefaultTableName = select_.from.DefaultName()
-	}
+	context.DefaultTableName = select_.from.DefaultName()
 
 	// select
 	columns := []string{}
@@ -193,11 +192,6 @@ func (c SQLCompiler) VisitSelect(context *CompilerContext, select_ SelectStmt) s
 
 	// from
 	addLine(fmt.Sprintf("FROM %s", select_.from.Accept(context)))
-
-	// joins
-	for _, j := range select_.joins {
-		addLine(j.Accept(context))
-	}
 
 	// where
 	if select_.where != nil {

--- a/compiler.go
+++ b/compiler.go
@@ -2,6 +2,7 @@ package qb
 
 import (
 	"fmt"
+	"strings"
 )
 
 func NewCompilerContext(compiler Compiler) *CompilerContext {
@@ -24,6 +25,7 @@ type Compiler interface {
 	VisitColumn(*CompilerContext, ColumnElem) string
 	VisitJoin(*CompilerContext, JoinClause) string
 	VisitLabel(*CompilerContext, string) string
+	VisitOrderBy(*CompilerContext, OrderByClause) string
 }
 
 type SQLCompiler struct {
@@ -58,4 +60,13 @@ func (c SQLCompiler) VisitJoin(context *CompilerContext, join JoinClause) string
 
 func (c SQLCompiler) VisitLabel(context *CompilerContext, label string) string {
 	return c.Dialect.Escape(label)
+}
+
+func (c SQLCompiler) VisitOrderBy(context *CompilerContext, orderBy OrderByClause) string {
+	cols := []string{}
+	for _, c := range orderBy.columns {
+		cols = append(cols, c.Accept(context))
+	}
+
+	return fmt.Sprintf("ORDER BY %s %s", strings.Join(cols, ", "), orderBy.t)
 }

--- a/compiler.go
+++ b/compiler.go
@@ -24,6 +24,7 @@ type CompilerContext struct {
 
 type Compiler interface {
 	VisitAggregate(*CompilerContext, AggregateClause) string
+	VisitAlias(*CompilerContext, AliasClause) string
 	VisitColumn(*CompilerContext, ColumnElem) string
 	VisitCombiner(*CompilerContext, CombinerClause) string
 	VisitCondition(*CompilerContext, Conditional) string
@@ -46,6 +47,14 @@ type SQLCompiler struct {
 
 func (c SQLCompiler) VisitAggregate(context *CompilerContext, aggregate AggregateClause) string {
 	return fmt.Sprintf("%s(%s)", aggregate.fn, aggregate.column.Accept(context))
+}
+
+func (SQLCompiler) VisitAlias(context *CompilerContext, alias AliasClause) string {
+	return fmt.Sprintf(
+		"%s AS %s",
+		alias.Selectable.Accept(context),
+		context.Dialect.Escape(alias.Name),
+	)
 }
 
 func (c SQLCompiler) VisitColumn(context *CompilerContext, column ColumnElem) string {

--- a/compiler.go
+++ b/compiler.go
@@ -29,6 +29,7 @@ type Compiler interface {
 	VisitCondition(*CompilerContext, Conditional) string
 	VisitDelete(*CompilerContext, DeleteStmt) string
 	VisitHaving(*CompilerContext, HavingClause) string
+	VisitInsert(*CompilerContext, InsertStmt) string
 	VisitJoin(*CompilerContext, JoinClause) string
 	VisitLabel(*CompilerContext, string) string
 	VisitOrderBy(*CompilerContext, OrderByClause) string
@@ -107,6 +108,42 @@ func (c SQLCompiler) VisitHaving(context *CompilerContext, having HavingClause) 
 	aggSQL := having.aggregate.Accept(context)
 	context.Binds = append(context.Binds, having.value)
 	return fmt.Sprintf("HAVING %s %s %s", aggSQL, having.op, context.Dialect.Placeholder())
+}
+
+func (c SQLCompiler) VisitInsert(context *CompilerContext, insert InsertStmt) string {
+	var (
+		colNames     []string
+		placeholders []string
+	)
+
+	context.DefaultTableName = insert.table.Name
+	defer func() { context.DefaultTableName = "" }()
+
+	for k, v := range insert.values {
+		colNames = append(colNames, context.Compiler.VisitLabel(context, k))
+		placeholders = append(placeholders, context.Dialect.Placeholder())
+		context.Binds = append(context.Binds, v)
+	}
+
+	sql := fmt.Sprintf(
+		"INSERT INTO %s(%s)\nVALUES(%s)",
+		context.Compiler.VisitLabel(context, insert.table.Name),
+		strings.Join(colNames, ", "),
+		strings.Join(placeholders, ", "),
+	)
+
+	returning := []string{}
+	for _, r := range insert.returning {
+		returning = append(returning, r.Accept(context))
+	}
+	if len(insert.returning) > 0 {
+		sql += fmt.Sprintf(
+			"\nRETURNING %s",
+			strings.Join(returning, ", "),
+		)
+	}
+
+	return sql
 }
 
 func (c SQLCompiler) VisitJoin(context *CompilerContext, join JoinClause) string {

--- a/compiler.go
+++ b/compiler.go
@@ -170,15 +170,16 @@ func (c SQLCompiler) VisitInsert(context *CompilerContext, insert InsertStmt) st
 	return sql
 }
 
+// VisitJoin compiles a JOIN (ON) clause
 func (c SQLCompiler) VisitJoin(context *CompilerContext, join JoinClause) string {
 	sql := fmt.Sprintf(
 		"%s\n%s %s",
-		join.left.Accept(context),
-		join.joinType,
-		join.right.Accept(context),
+		join.Left.Accept(context),
+		join.JoinType,
+		join.Right.Accept(context),
 	)
-	if (join.leftCol.Name != "") || (join.rightCol.Name != "") {
-		sql += " ON " + join.leftCol.Accept(context) + " = " + join.rightCol.Accept(context)
+	if join.OnClause != nil {
+		sql += " ON " + join.OnClause.Accept(context)
 	}
 
 	return sql

--- a/compiler.go
+++ b/compiler.go
@@ -1,0 +1,42 @@
+package qb
+
+import (
+	"fmt"
+)
+
+func NewCompilerContext(compiler Compiler) *CompilerContext {
+	return &CompilerContext{
+		Compiler: compiler,
+		Vars:     make(map[string]interface{}),
+	}
+}
+
+type CompilerContext struct {
+	Binds            []interface{}
+	DefaultTableName string
+	Vars             map[string]interface{}
+
+	Compiler Compiler
+}
+
+type Compiler interface {
+	VisitAggregate(*CompilerContext, AggregateClause) string
+	VisitColumn(*CompilerContext, ColumnElem) string
+}
+
+type SQLCompiler struct {
+	Dialect Dialect
+}
+
+func (c SQLCompiler) VisitAggregate(context *CompilerContext, aggregate AggregateClause) string {
+	return fmt.Sprintf("%s(%s)", aggregate.fn, aggregate.column.Accept(context))
+}
+
+func (c SQLCompiler) VisitColumn(context *CompilerContext, column ColumnElem) string {
+	sql := ""
+	if context.DefaultTableName != column.Table {
+		sql += c.Dialect.Escape(column.Table) + "."
+	}
+	sql += c.Dialect.Escape(column.Name)
+	return sql
+}

--- a/compiler.go
+++ b/compiler.go
@@ -25,14 +25,16 @@ type CompilerContext struct {
 type Compiler interface {
 	VisitAggregate(*CompilerContext, AggregateClause) string
 	VisitAlias(*CompilerContext, AliasClause) string
+	VisitBinary(*CompilerContext, BinaryExpressionClause) string
+	VisitBind(*CompilerContext, BindClause) string
 	VisitColumn(*CompilerContext, ColumnElem) string
 	VisitCombiner(*CompilerContext, CombinerClause) string
-	VisitCondition(*CompilerContext, Conditional) string
 	VisitDelete(*CompilerContext, DeleteStmt) string
 	VisitHaving(*CompilerContext, HavingClause) string
 	VisitInsert(*CompilerContext, InsertStmt) string
 	VisitJoin(*CompilerContext, JoinClause) string
 	VisitLabel(*CompilerContext, string) string
+	VisitList(*CompilerContext, ListClause) string
 	VisitOrderBy(*CompilerContext, OrderByClause) string
 	VisitSelect(*CompilerContext, SelectStmt) string
 	VisitTable(*CompilerContext, TableElem) string
@@ -58,6 +60,22 @@ func (SQLCompiler) VisitAlias(context *CompilerContext, alias AliasClause) strin
 	)
 }
 
+// VisitBinary compiles LEFT <op> RIGHT expressions
+func (c SQLCompiler) VisitBinary(context *CompilerContext, binary BinaryExpressionClause) string {
+	return fmt.Sprintf(
+		"%s %s %s",
+		binary.Left.Accept(context),
+		binary.Op,
+		binary.Right.Accept(context),
+	)
+}
+
+// VisitBind renders a bounded value
+func (SQLCompiler) VisitBind(context *CompilerContext, bind BindClause) string {
+	context.Binds = append(context.Binds, bind.Value)
+	return context.Dialect.Placeholder()
+}
+
 func (c SQLCompiler) VisitColumn(context *CompilerContext, column ColumnElem) string {
 	sql := ""
 	if context.DefaultTableName != column.Table {
@@ -75,26 +93,6 @@ func (c SQLCompiler) VisitCombiner(context *CompilerContext, combiner CombinerCl
 	}
 
 	return fmt.Sprintf("(%s)", strings.Join(sqls, fmt.Sprintf(" %s ", combiner.operator)))
-}
-
-func (c SQLCompiler) VisitCondition(context *CompilerContext, condition Conditional) string {
-	var sql string
-	key := condition.Col.Accept(context)
-
-	switch condition.Op {
-	case "IN":
-		sql = fmt.Sprintf("%s %s (%s)", key, condition.Op, strings.Join(context.Dialect.Placeholders(condition.Values...), ", "))
-		context.Binds = append(context.Binds, condition.Values...)
-	case "NOT IN":
-		sql = fmt.Sprintf("%s %s (%s)", key, condition.Op, strings.Join(context.Dialect.Placeholders(condition.Values...), ", "))
-		context.Binds = append(context.Binds, condition.Values...)
-	case "LIKE":
-		sql = fmt.Sprintf("%s %s '%s'", key, condition.Op, condition.Values[0])
-	default:
-		sql = fmt.Sprintf("%s %s %s", key, condition.Op, context.Dialect.Placeholder())
-		context.Binds = append(context.Binds, condition.Values...)
-	}
-	return sql
 }
 
 func (c SQLCompiler) VisitDelete(context *CompilerContext, delete DeleteStmt) string {
@@ -174,6 +172,14 @@ func (c SQLCompiler) VisitJoin(context *CompilerContext, join JoinClause) string
 
 func (c SQLCompiler) VisitLabel(context *CompilerContext, label string) string {
 	return c.Dialect.Escape(label)
+}
+
+func (c SQLCompiler) VisitList(context *CompilerContext, list ListClause) string {
+	var clauses []string
+	for _, clause := range list.Clauses {
+		clauses = append(clauses, clause.Accept(context))
+	}
+	return fmt.Sprintf("(%s)", strings.Join(clauses, ", "))
 }
 
 func (c SQLCompiler) VisitOrderBy(context *CompilerContext, orderBy OrderByClause) string {

--- a/compiler.go
+++ b/compiler.go
@@ -152,10 +152,10 @@ func (c SQLCompiler) VisitJoin(context *CompilerContext, join JoinClause) string
 	sql := fmt.Sprintf(
 		"%s %s",
 		join.joinType,
-		context.Compiler.VisitLabel(context, join.table.Name),
+		join.right.Accept(context),
 	)
-	if (join.fromCol.Name != "") || (join.col.Name != "") {
-		sql += " ON " + join.fromCol.Accept(context) + " = " + join.col.Accept(context)
+	if (join.leftCol.Name != "") || (join.rightCol.Name != "") {
+		sql += " ON " + join.leftCol.Accept(context) + " = " + join.rightCol.Accept(context)
 	}
 
 	return sql
@@ -180,7 +180,7 @@ func (c SQLCompiler) VisitSelect(context *CompilerContext, select_ SelectStmt) s
 		lines = append(lines, s)
 	}
 	if len(select_.joins) == 0 {
-		context.DefaultTableName = select_.from.Name
+		context.DefaultTableName = select_.from.DefaultName()
 	}
 
 	// select

--- a/compiler.go
+++ b/compiler.go
@@ -31,6 +31,7 @@ type Compiler interface {
 	VisitJoin(*CompilerContext, JoinClause) string
 	VisitLabel(*CompilerContext, string) string
 	VisitOrderBy(*CompilerContext, OrderByClause) string
+	VisitSelect(*CompilerContext, SelectStmt) string
 	VisitWhere(*CompilerContext, WhereClause) string
 }
 
@@ -111,6 +112,64 @@ func (c SQLCompiler) VisitOrderBy(context *CompilerContext, orderBy OrderByClaus
 	}
 
 	return fmt.Sprintf("ORDER BY %s %s", strings.Join(cols, ", "), orderBy.t)
+}
+
+func (c SQLCompiler) VisitSelect(context *CompilerContext, select_ SelectStmt) string {
+	lines := []string{}
+	addLine := func(s string) {
+		lines = append(lines, s)
+	}
+	if len(select_.joins) == 0 {
+		context.DefaultTableName = select_.from.Name
+	}
+
+	// select
+	columns := []string{}
+	for _, c := range select_.sel {
+		sql := c.Accept(context)
+		columns = append(columns, sql)
+	}
+	addLine(fmt.Sprintf("SELECT %s", strings.Join(columns, ", ")))
+
+	// from
+	addLine(fmt.Sprintf("FROM %s", context.Dialect.Escape(select_.from.Name)))
+
+	// joins
+	for _, j := range select_.joins {
+		addLine(j.Accept(context))
+	}
+
+	// where
+	if select_.where != nil {
+		addLine(select_.where.Accept(context))
+	}
+
+	// group by
+	groupByCols := []string{}
+	for _, c := range select_.groupBy {
+		groupByCols = append(groupByCols, context.Dialect.Escape(c.Name))
+	}
+	if len(groupByCols) > 0 {
+		addLine(fmt.Sprintf("GROUP BY %s", strings.Join(groupByCols, ", ")))
+	}
+
+	// having
+	for _, h := range select_.having {
+		sql := h.Accept(context)
+		addLine(sql)
+	}
+
+	// order by
+	if select_.orderBy != nil {
+		sql := select_.orderBy.Accept(context)
+		addLine(sql)
+	}
+
+	if (select_.offset != nil) && (select_.count != nil) {
+		addLine(fmt.Sprintf("LIMIT %d OFFSET %d", *select_.count, *select_.offset))
+	}
+
+	return strings.Join(lines, "\n")
 }
 
 func (c SQLCompiler) VisitWhere(context *CompilerContext, where WhereClause) string {

--- a/compiler_test.go
+++ b/compiler_test.go
@@ -5,12 +5,38 @@ import (
 	"testing"
 )
 
+var (
+	TTGroup = Table(
+		"group",
+		Column("id", Int()).AutoIncrement().PrimaryKey(),
+		Column("name", Text()).Unique(),
+	)
+
+	TTUser = Table(
+		"user",
+		Column("id", Int()).AutoIncrement().PrimaryKey(),
+		Column("name", Text()).Unique(),
+		Column("main_group_id", Int()),
+		ForeignKey().Ref("main_group_id", "group", "id"),
+	)
+)
+
 var compileTests = []struct {
 	clause Clause
 	expect string
 	binds  []interface{}
 }{
 	{SQLText("1"), "1", nil},
+	{
+		Exists(Select(TTGroup.C("name")).From(TTGroup).Where(TTGroup.C("id").Eq(TTUser.C("main_group_id")))),
+		"EXISTS(SELECT group.name\nFROM group\nWHERE group.id = user.main_group_id)",
+		nil,
+	},
+	{
+		NotExists(Select(TTGroup.C("name")).From(TTGroup).Where(TTGroup.C("id").Eq(TTUser.C("main_group_id")))),
+		"NOT EXISTS(SELECT group.name\nFROM group\nWHERE group.id = user.main_group_id)",
+		nil,
+	},
 }
 
 func TestCompile(t *testing.T) {

--- a/compiler_test.go
+++ b/compiler_test.go
@@ -1,0 +1,27 @@
+package qb
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+var compileTests = []struct {
+	clause Clause
+	expect string
+	binds  []interface{}
+}{
+	{SQLText("1"), "1", nil},
+}
+
+func TestCompile(t *testing.T) {
+	compile := func(clause Clause) (string, []interface{}) {
+		context := NewCompilerContext(NewDialect("default"))
+		return clause.Accept(context), context.Binds
+	}
+
+	for _, tt := range compileTests {
+		actual, binds := compile(tt.clause)
+		assert.Equal(t, tt.expect, actual)
+		assert.Equal(t, tt.binds, binds)
+	}
+}

--- a/compiler_test.go
+++ b/compiler_test.go
@@ -28,6 +28,21 @@ var compileTests = []struct {
 }{
 	{SQLText("1"), "1", nil},
 	{
+		Join("LEFT JOIN", TTGroup, TTUser),
+		"group\nLEFT JOIN user ON user.main_group_id = group.id",
+		nil,
+	},
+	{
+		Join("LEFT JOIN", TTGroup, TTUser, TTGroup.C("id").Eq(TTUser.C("id"))),
+		"group\nLEFT JOIN user ON group.id = user.id",
+		nil,
+	},
+	{
+		Join("LEFT JOIN", TTGroup, TTUser, TTGroup.C("id"), TTUser.C("id")),
+		"group\nLEFT JOIN user ON group.id = user.id",
+		nil,
+	},
+	{
 		Exists(Select(TTGroup.C("name")).From(TTGroup).Where(TTGroup.C("id").Eq(TTUser.C("main_group_id")))),
 		"EXISTS(SELECT group.name\nFROM group\nWHERE group.id = user.main_group_id)",
 		nil,

--- a/conditional.go
+++ b/conditional.go
@@ -3,63 +3,77 @@ package qb
 // conditional generators, comparator functions
 
 // Like generates a like conditional sql clause
-func Like(col ColumnElem, pattern string) Conditional {
-	return Condition(col, "LIKE", pattern)
+func Like(left Clause, right interface{}) BinaryExpressionClause {
+	return BinaryExpression(left, "LIKE", GetClauseFrom(right))
 }
 
 // NotIn generates a not in conditional sql clause
-func NotIn(col ColumnElem, values ...interface{}) Conditional {
-	return Condition(col, "NOT IN", values...)
+func NotIn(left Clause, values ...interface{}) BinaryExpressionClause {
+	return NotInClause(left, GetListFrom(values))
+}
+
+// NotInClause generates a NOT IN clause
+func NotInClause(left Clause, right Clause) BinaryExpressionClause {
+	return BinaryExpression(left, "NOT IN", right)
 }
 
 // In generates an in conditional sql clause
-func In(col ColumnElem, values ...interface{}) Conditional {
-	return Condition(col, "IN", values...)
+func In(left Clause, values ...interface{}) BinaryExpressionClause {
+	return InClause(left, GetListFrom(values))
+}
+
+// InClause generates an in conditional sql clause
+func InClause(left Clause, right Clause) BinaryExpressionClause {
+	return BinaryExpression(left, "IN", right)
 }
 
 // NotEq generates a not equal conditional sql clause
-func NotEq(col ColumnElem, value interface{}) Conditional {
-	return Condition(col, "!=", value)
+func NotEq(left Clause, right interface{}) BinaryExpressionClause {
+	return BinaryExpression(left, "!=", GetClauseFrom(right))
 }
 
 // Eq generates a equals conditional sql clause
-func Eq(col ColumnElem, value interface{}) Conditional {
-	return Condition(col, "=", value)
+func Eq(left Clause, right interface{}) BinaryExpressionClause {
+	return BinaryExpression(left, "=", GetClauseFrom(right))
 }
 
 // Gt generates a greater than conditional sql clause
-func Gt(col ColumnElem, value interface{}) Conditional {
-	return Condition(col, ">", value)
+func Gt(left Clause, right interface{}) BinaryExpressionClause {
+	return BinaryExpression(left, ">", GetClauseFrom(right))
 }
 
 // Lt generates a less than conditional sql clause
-func Lt(col ColumnElem, value interface{}) Conditional {
-	return Condition(col, "<", value)
+func Lt(left Clause, right interface{}) BinaryExpressionClause {
+	return BinaryExpression(left, "<", GetClauseFrom(right))
 }
 
 // Gte generates a greater than or equal to conditional sql clause
-func Gte(col ColumnElem, value interface{}) Conditional {
-	return Condition(col, ">=", value)
+func Gte(left Clause, right interface{}) BinaryExpressionClause {
+	return BinaryExpression(left, ">=", GetClauseFrom(right))
 }
 
 // Lte generates a less than or equal to conditional sql clause
-func Lte(col ColumnElem, value interface{}) Conditional {
-	return Condition(col, "<=", value)
+func Lte(left Clause, right interface{}) BinaryExpressionClause {
+	return BinaryExpression(left, "<=", GetClauseFrom(right))
 }
 
-// Condition generates a condition object to use in update, delete & select statements
-func Condition(col ColumnElem, op string, values ...interface{}) Conditional {
-	return Conditional{col, values, op}
+// BinaryExpression generates a condition object to use in update, delete & select statements
+func BinaryExpression(left Clause, op string, right Clause) BinaryExpressionClause {
+	return BinaryExpressionClause{
+		Left:  left,
+		Right: right,
+		Op:    op,
+	}
 }
 
-// Conditional is the base struct for any conditional statements in sql clauses
-type Conditional struct {
-	Col    ColumnElem
-	Values []interface{}
-	Op     string
+// BinaryExpressionClause is the base struct for any conditional statements in sql clauses
+type BinaryExpressionClause struct {
+	Left  Clause
+	Right Clause
+	Op    string
 }
 
-// Accept compiles the conditional element
-func (c Conditional) Accept(context *CompilerContext) string {
-	return context.Compiler.VisitCondition(context, c)
+// Accept calls the compiler VisitBinary method
+func (c BinaryExpressionClause) Accept(context *CompilerContext) string {
+	return context.Compiler.VisitBinary(context, c)
 }

--- a/conditional.go
+++ b/conditional.go
@@ -1,10 +1,5 @@
 package qb
 
-import (
-	"fmt"
-	"strings"
-)
-
 // conditional generators, comparator functions
 
 // Like generates a like conditional sql clause
@@ -64,26 +59,7 @@ type Conditional struct {
 	Op     string
 }
 
-// Build compiles the conditional element
-func (c Conditional) Build(dialect Dialect) (string, []interface{}) {
-	var sql string
-	key := dialect.Escape(c.Col.Name)
-	if c.Col.Table != "" {
-		key = fmt.Sprintf("%s.%s", dialect.Escape(c.Col.Table), key)
-	}
-
-	switch c.Op {
-	case "IN":
-		sql = fmt.Sprintf("%s %s (%s)", key, c.Op, strings.Join(dialect.Placeholders(c.Values...), ", "))
-		return sql, c.Values
-	case "NOT IN":
-		sql = fmt.Sprintf("%s %s (%s)", key, c.Op, strings.Join(dialect.Placeholders(c.Values...), ", "))
-		return sql, c.Values
-	case "LIKE":
-		sql = fmt.Sprintf("%s %s '%s'", key, c.Op, c.Values[0])
-		return sql, []interface{}{}
-	default:
-		sql = fmt.Sprintf("%s %s %s", key, c.Op, dialect.Placeholder())
-		return sql, c.Values
-	}
+// Accept compiles the conditional element
+func (c Conditional) Accept(context *CompilerContext) string {
+	return context.Compiler.VisitCondition(context, c)
 }

--- a/conditional_test.go
+++ b/conditional_test.go
@@ -7,6 +7,11 @@ import (
 
 func TestConditionals(t *testing.T) {
 
+	compile := func(c Clause, d Dialect) (string, []interface{}) {
+		ctx := NewCompilerContext(d)
+		return c.Accept(ctx), ctx.Binds
+	}
+
 	sqlite := NewDialect("sqlite3")
 	sqlite.SetEscaping(true)
 
@@ -23,68 +28,68 @@ func TestConditionals(t *testing.T) {
 
 	like := Like(country, "%land%")
 
-	sql, _ = like.Build(sqlite)
+	sql, _ = compile(like, sqlite)
 	assert.Equal(t, "country LIKE '%land%'", sql)
 
-	sql, _ = like.Build(mysql)
+	sql, _ = compile(like, mysql)
 	assert.Equal(t, "`country` LIKE '%land%'", sql)
 
-	sql, _ = like.Build(postgres)
+	sql, _ = compile(like, postgres)
 	assert.Equal(t, "\"country\" LIKE '%land%'", sql)
 
 	notIn := NotIn(country, "USA", "England", "Sweden")
 
-	sql, bindings = notIn.Build(sqlite)
+	sql, bindings = compile(notIn, sqlite)
 	assert.Equal(t, "country NOT IN (?, ?, ?)", sql)
 	assert.Equal(t, []interface{}{"USA", "England", "Sweden"}, bindings)
 
-	sql, bindings = notIn.Build(mysql)
+	sql, bindings = compile(notIn, mysql)
 	assert.Equal(t, "`country` NOT IN (?, ?, ?)", sql)
 	assert.Equal(t, []interface{}{"USA", "England", "Sweden"}, bindings)
 
-	sql, bindings = notIn.Build(postgres)
+	sql, bindings = compile(notIn, postgres)
 	assert.Equal(t, "\"country\" NOT IN ($1, $2, $3)", sql)
 	assert.Equal(t, []interface{}{"USA", "England", "Sweden"}, bindings)
 
 	in := In(country, "USA", "England", "Sweden")
 
-	sql, bindings = in.Build(sqlite)
+	sql, bindings = compile(in, sqlite)
 	assert.Equal(t, "country IN (?, ?, ?)", sql)
 	assert.Equal(t, []interface{}{"USA", "England", "Sweden"}, bindings)
 
-	sql, bindings = in.Build(mysql)
+	sql, bindings = compile(in, mysql)
 	assert.Equal(t, "`country` IN (?, ?, ?)", sql)
 	assert.Equal(t, []interface{}{"USA", "England", "Sweden"}, bindings)
 
-	sql, bindings = in.Build(postgres)
+	sql, bindings = compile(in, postgres)
 	assert.Equal(t, "\"country\" IN ($4, $5, $6)", sql)
 	assert.Equal(t, []interface{}{"USA", "England", "Sweden"}, bindings)
 
 	notEq := NotEq(country, "USA")
 
-	sql, bindings = notEq.Build(sqlite)
+	sql, bindings = compile(notEq, sqlite)
 	assert.Equal(t, "country != ?", sql)
 	assert.Equal(t, []interface{}{"USA"}, bindings)
 
-	sql, bindings = notEq.Build(mysql)
+	sql, bindings = compile(notEq, mysql)
 	assert.Equal(t, "`country` != ?", sql)
 	assert.Equal(t, []interface{}{"USA"}, bindings)
 
-	sql, bindings = notEq.Build(postgres)
+	sql, bindings = compile(notEq, postgres)
 	assert.Equal(t, "\"country\" != $7", sql)
 	assert.Equal(t, []interface{}{"USA"}, bindings)
 
 	eq := Eq(country, "Turkey")
 
-	sql, bindings = eq.Build(sqlite)
+	sql, bindings = compile(eq, sqlite)
 	assert.Equal(t, "country = ?", sql)
 	assert.Equal(t, []interface{}{"Turkey"}, bindings)
 
-	sql, bindings = eq.Build(mysql)
+	sql, bindings = compile(eq, mysql)
 	assert.Equal(t, "`country` = ?", sql)
 	assert.Equal(t, []interface{}{"Turkey"}, bindings)
 
-	sql, bindings = eq.Build(postgres)
+	sql, bindings = compile(eq, postgres)
 	assert.Equal(t, "\"country\" = $8", sql)
 	assert.Equal(t, []interface{}{"Turkey"}, bindings)
 
@@ -92,57 +97,59 @@ func TestConditionals(t *testing.T) {
 
 	gt := Gt(score, 1500)
 
-	sql, bindings = gt.Build(sqlite)
+	sql, bindings = compile(gt, sqlite)
 	assert.Equal(t, "score > ?", sql)
 	assert.Equal(t, []interface{}{1500}, bindings)
 
-	sql, bindings = gt.Build(mysql)
+	sql, bindings = compile(gt, mysql)
 	assert.Equal(t, "`score` > ?", sql)
 	assert.Equal(t, []interface{}{1500}, bindings)
 
-	sql, bindings = gt.Build(postgres)
+	sql, bindings = compile(gt, postgres)
 	assert.Equal(t, "\"score\" > $9", sql)
 	assert.Equal(t, []interface{}{1500}, bindings)
 
 	lt := Lt(score, 1500)
 
-	sql, bindings = lt.Build(sqlite)
+	sql, bindings = compile(lt, sqlite)
 	assert.Equal(t, "score < ?", sql)
 	assert.Equal(t, []interface{}{1500}, bindings)
 
-	sql, bindings = lt.Build(mysql)
+	sql, bindings = compile(lt, mysql)
 	assert.Equal(t, "`score` < ?", sql)
 	assert.Equal(t, []interface{}{1500}, bindings)
 
-	sql, bindings = lt.Build(postgres)
+	sql, bindings = compile(lt, postgres)
+
 	assert.Equal(t, "\"score\" < $10", sql)
 	assert.Equal(t, []interface{}{1500}, bindings)
 
 	gte := Gte(score, 1500)
 
-	sql, bindings = gte.Build(sqlite)
+	sql, bindings = compile(gte, sqlite)
 	assert.Equal(t, "score >= ?", sql)
 	assert.Equal(t, []interface{}{1500}, bindings)
 
-	sql, bindings = gte.Build(mysql)
+	sql, bindings = compile(gte, mysql)
 	assert.Equal(t, "`score` >= ?", sql)
 	assert.Equal(t, []interface{}{1500}, bindings)
 
-	sql, bindings = gte.Build(postgres)
+	sql, bindings = compile(gte, postgres)
 	assert.Equal(t, "\"score\" >= $11", sql)
 	assert.Equal(t, []interface{}{1500}, bindings)
 
 	lte := Lte(score, 1500)
 
-	sql, bindings = lte.Build(sqlite)
+	sql, bindings = compile(lte, sqlite)
 	assert.Equal(t, "score <= ?", sql)
 	assert.Equal(t, []interface{}{1500}, bindings)
 
-	sql, bindings = lte.Build(mysql)
+	sql, bindings = compile(lte, mysql)
 	assert.Equal(t, "`score` <= ?", sql)
 	assert.Equal(t, []interface{}{1500}, bindings)
 
-	sql, bindings = lte.Build(postgres)
+	sql, bindings = compile(lte, postgres)
+
 	assert.Equal(t, "\"score\" <= $12", sql)
 	assert.Equal(t, []interface{}{1500}, bindings)
 

--- a/conditional_test.go
+++ b/conditional_test.go
@@ -8,6 +8,7 @@ import (
 func TestConditionals(t *testing.T) {
 
 	compile := func(c Clause, d Dialect) (string, []interface{}) {
+		defer d.Reset()
 		ctx := NewCompilerContext(d)
 		return c.Accept(ctx), ctx.Binds
 	}
@@ -28,14 +29,17 @@ func TestConditionals(t *testing.T) {
 
 	like := Like(country, "%land%")
 
-	sql, _ = compile(like, sqlite)
-	assert.Equal(t, "country LIKE '%land%'", sql)
+	sql, bindings = compile(like, sqlite)
+	assert.Equal(t, "country LIKE ?", sql)
+	assert.Equal(t, []interface{}{"%land%"}, bindings)
 
 	sql, _ = compile(like, mysql)
-	assert.Equal(t, "`country` LIKE '%land%'", sql)
+	assert.Equal(t, "`country` LIKE ?", sql)
+	assert.Equal(t, []interface{}{"%land%"}, bindings)
 
 	sql, _ = compile(like, postgres)
-	assert.Equal(t, "\"country\" LIKE '%land%'", sql)
+	assert.Equal(t, "\"country\" LIKE $1", sql)
+	assert.Equal(t, []interface{}{"%land%"}, bindings)
 
 	notIn := NotIn(country, "USA", "England", "Sweden")
 
@@ -62,7 +66,7 @@ func TestConditionals(t *testing.T) {
 	assert.Equal(t, []interface{}{"USA", "England", "Sweden"}, bindings)
 
 	sql, bindings = compile(in, postgres)
-	assert.Equal(t, "\"country\" IN ($4, $5, $6)", sql)
+	assert.Equal(t, "\"country\" IN ($1, $2, $3)", sql)
 	assert.Equal(t, []interface{}{"USA", "England", "Sweden"}, bindings)
 
 	notEq := NotEq(country, "USA")
@@ -76,7 +80,7 @@ func TestConditionals(t *testing.T) {
 	assert.Equal(t, []interface{}{"USA"}, bindings)
 
 	sql, bindings = compile(notEq, postgres)
-	assert.Equal(t, "\"country\" != $7", sql)
+	assert.Equal(t, "\"country\" != $1", sql)
 	assert.Equal(t, []interface{}{"USA"}, bindings)
 
 	eq := Eq(country, "Turkey")
@@ -90,7 +94,7 @@ func TestConditionals(t *testing.T) {
 	assert.Equal(t, []interface{}{"Turkey"}, bindings)
 
 	sql, bindings = compile(eq, postgres)
-	assert.Equal(t, "\"country\" = $8", sql)
+	assert.Equal(t, "\"country\" = $1", sql)
 	assert.Equal(t, []interface{}{"Turkey"}, bindings)
 
 	score := Column("score", BigInt()).NotNull()
@@ -106,7 +110,7 @@ func TestConditionals(t *testing.T) {
 	assert.Equal(t, []interface{}{1500}, bindings)
 
 	sql, bindings = compile(gt, postgres)
-	assert.Equal(t, "\"score\" > $9", sql)
+	assert.Equal(t, "\"score\" > $1", sql)
 	assert.Equal(t, []interface{}{1500}, bindings)
 
 	lt := Lt(score, 1500)
@@ -121,7 +125,7 @@ func TestConditionals(t *testing.T) {
 
 	sql, bindings = compile(lt, postgres)
 
-	assert.Equal(t, "\"score\" < $10", sql)
+	assert.Equal(t, "\"score\" < $1", sql)
 	assert.Equal(t, []interface{}{1500}, bindings)
 
 	gte := Gte(score, 1500)
@@ -135,7 +139,7 @@ func TestConditionals(t *testing.T) {
 	assert.Equal(t, []interface{}{1500}, bindings)
 
 	sql, bindings = compile(gte, postgres)
-	assert.Equal(t, "\"score\" >= $11", sql)
+	assert.Equal(t, "\"score\" >= $1", sql)
 	assert.Equal(t, []interface{}{1500}, bindings)
 
 	lte := Lte(score, 1500)
@@ -150,7 +154,7 @@ func TestConditionals(t *testing.T) {
 
 	sql, bindings = compile(lte, postgres)
 
-	assert.Equal(t, "\"score\" <= $12", sql)
+	assert.Equal(t, "\"score\" <= $1", sql)
 	assert.Equal(t, []interface{}{1500}, bindings)
 
 }

--- a/delete.go
+++ b/delete.go
@@ -1,10 +1,5 @@
 package qb
 
-import (
-	"fmt"
-	"strings"
-)
-
 // Delete generates a delete statement and returns it for chaining
 // qb.Delete(usersTable).Where(qb.Eq("id", 5))
 func Delete(table TableElem) DeleteStmt {
@@ -34,27 +29,19 @@ func (s DeleteStmt) Returning(cols ...ColumnElem) DeleteStmt {
 	return s
 }
 
+// Accept implements Clause.Accept
+func (s DeleteStmt) Accept(context *CompilerContext) string {
+	return context.Compiler.VisitDelete(context, s)
+}
+
 // Build generates a statement out of DeleteStmt object
 func (s DeleteStmt) Build(dialect Dialect) *Stmt {
 	defer dialect.Reset()
 
 	context := NewCompilerContext(dialect)
 	statement := Statement()
-	statement.AddSQLClause(fmt.Sprintf("DELETE FROM %s", dialect.Escape(s.table.Name)))
-	if s.where != nil {
-		where := s.where.Accept(context)
-		statement.AddSQLClause(where)
-	}
+	statement.AddSQLClause(s.Accept(context))
 	statement.AddBinding(context.Binds...)
-
-	returning := []string{}
-	for _, c := range s.returning {
-		returning = append(returning, dialect.Escape(c.Name))
-	}
-
-	if len(returning) > 0 {
-		statement.AddSQLClause(fmt.Sprintf("RETURNING %s", strings.Join(returning, ", ")))
-	}
 
 	return statement
 }

--- a/delete.go
+++ b/delete.go
@@ -17,13 +17,13 @@ func Delete(table TableElem) DeleteStmt {
 // DeleteStmt is the base struct for building delete queries
 type DeleteStmt struct {
 	table     TableElem
-	where     *WhereClause
+	where     *WhereSQLClause
 	returning []ColumnElem
 }
 
 // Where adds a where clause to the current delete statement
-func (s DeleteStmt) Where(clause Clause) DeleteStmt {
-	s.where = &WhereClause{clause}
+func (s DeleteStmt) Where(clause SQLClause) DeleteStmt {
+	s.where = &WhereSQLClause{clause}
 	return s
 }
 
@@ -39,10 +39,10 @@ func (s DeleteStmt) Build(dialect Dialect) *Stmt {
 	defer dialect.Reset()
 
 	statement := Statement()
-	statement.AddClause(fmt.Sprintf("DELETE FROM %s", dialect.Escape(s.table.Name)))
+	statement.AddSQLClause(fmt.Sprintf("DELETE FROM %s", dialect.Escape(s.table.Name)))
 	if s.where != nil {
 		where, whereBindings := s.where.Build(dialect)
-		statement.AddClause(where)
+		statement.AddSQLClause(where)
 		statement.AddBinding(whereBindings...)
 	}
 
@@ -52,7 +52,7 @@ func (s DeleteStmt) Build(dialect Dialect) *Stmt {
 	}
 
 	if len(returning) > 0 {
-		statement.AddClause(fmt.Sprintf("RETURNING %s", strings.Join(returning, ", ")))
+		statement.AddSQLClause(fmt.Sprintf("RETURNING %s", strings.Join(returning, ", ")))
 	}
 
 	return statement

--- a/dialect.go
+++ b/dialect.go
@@ -17,6 +17,7 @@ func NewDialect(driver string) Dialect {
 // Dialect is the common interface for driver changes
 // It is for fixing compatibility issues of different drivers
 type Dialect interface {
+	GetCompiler() Compiler
 	CompileType(t TypeElem) string
 	Escape(str string) string
 	EscapeAll([]string) []string

--- a/dialect_default.go
+++ b/dialect_default.go
@@ -65,3 +65,7 @@ func (d *DefaultDialect) SupportsUnsigned() bool { return false }
 func (d *DefaultDialect) Driver() string {
 	return ""
 }
+
+func (d *DefaultDialect) GetCompiler() Compiler {
+	return SQLCompiler{d}
+}

--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -68,3 +68,7 @@ func (d *MysqlDialect) SupportsUnsigned() bool { return true }
 func (d *MysqlDialect) Driver() string {
 	return "mysql"
 }
+
+func (d *MysqlDialect) GetCompiler() Compiler {
+	return SQLCompiler{d}
+}

--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -1,6 +1,9 @@
 package qb
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // MysqlDialect is a type of dialect that can be used with mysql driver
 type MysqlDialect struct {
@@ -70,5 +73,42 @@ func (d *MysqlDialect) Driver() string {
 }
 
 func (d *MysqlDialect) GetCompiler() Compiler {
-	return SQLCompiler{d}
+	return MysqlCompiler{SQLCompiler{d}}
+}
+
+type MysqlCompiler struct {
+	SQLCompiler
+}
+
+// VisitUpsert generates INSERT INTO ... VALUES ... ON DUPLICATE KEY UPDATE ...
+func (MysqlCompiler) VisitUpsert(context *CompilerContext, upsert UpsertStmt) string {
+	var (
+		colNames []string
+		values   []string
+	)
+	for k, v := range upsert.values {
+		colNames = append(colNames, context.Compiler.VisitLabel(context, k))
+		context.Binds = append(context.Binds, v)
+		values = append(values, context.Dialect.Placeholder())
+	}
+
+	updates := []string{}
+	for k, v := range upsert.values {
+		updates = append(updates, fmt.Sprintf(
+			"%s = %s",
+			context.Dialect.Escape(k),
+			context.Dialect.Placeholder(),
+		))
+		context.Binds = append(context.Binds, v)
+	}
+
+	sql := fmt.Sprintf(
+		"INSERT INTO %s(%s)\nVALUES(%s)\nON DUPLICATE KEY UPDATE %s",
+		context.Dialect.Escape(upsert.table.Name),
+		strings.Join(colNames, ", "),
+		strings.Join(values, ", "),
+		strings.Join(updates, ", "),
+	)
+
+	return sql
 }

--- a/dialect_postgres.go
+++ b/dialect_postgres.go
@@ -73,3 +73,7 @@ func (d *PostgresDialect) SupportsUnsigned() bool { return false }
 func (d *PostgresDialect) Driver() string {
 	return "postgres"
 }
+
+func (d *PostgresDialect) GetCompiler() Compiler {
+	return SQLCompiler{d}
+}

--- a/dialect_postgres.go
+++ b/dialect_postgres.go
@@ -1,6 +1,9 @@
 package qb
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // PostgresDialect is a type of dialect that can be used with postgres driver
 type PostgresDialect struct {
@@ -75,5 +78,56 @@ func (d *PostgresDialect) Driver() string {
 }
 
 func (d *PostgresDialect) GetCompiler() Compiler {
-	return SQLCompiler{d}
+	return PostgresCompiler{SQLCompiler{d}}
+}
+
+type PostgresCompiler struct {
+	SQLCompiler
+}
+
+// VisitUpsert generates INSERT INTO ... VALUES ... ON CONFLICT(...) DO UPDATE SET ...
+func (PostgresCompiler) VisitUpsert(context *CompilerContext, upsert UpsertStmt) string {
+	var (
+		colNames []string
+		values   []string
+	)
+	for k, v := range upsert.values {
+		colNames = append(colNames, context.Compiler.VisitLabel(context, k))
+		context.Binds = append(context.Binds, v)
+		values = append(values, context.Dialect.Placeholder())
+	}
+
+	var updates []string
+	for k, v := range upsert.values {
+		updates = append(updates, fmt.Sprintf(
+			"%s = %s",
+			context.Dialect.Escape(k),
+			context.Dialect.Placeholder()))
+		context.Binds = append(context.Binds, v)
+	}
+
+	var uniqueCols []string
+	for _, c := range upsert.table.PrimaryCols() {
+		uniqueCols = append(uniqueCols, context.Compiler.VisitLabel(context, c.Name))
+	}
+
+	sql := fmt.Sprintf(
+		"INSERT INTO %s(%s)\nVALUES(%s)\nON CONFLICT (%s) DO UPDATE SET %s",
+		context.Compiler.VisitLabel(context, upsert.table.Name),
+		strings.Join(colNames, ", "),
+		strings.Join(values, ", "),
+		strings.Join(uniqueCols, ", "),
+		strings.Join(updates, ", "))
+
+	var returning []string
+	for _, r := range upsert.returning {
+		returning = append(returning, context.Compiler.VisitLabel(context, r.Name))
+	}
+	if len(upsert.returning) > 0 {
+		sql += fmt.Sprintf(
+			"RETURNING %s",
+			strings.Join(returning, ", "),
+		)
+	}
+	return sql
 }

--- a/dialect_sqlite.go
+++ b/dialect_sqlite.go
@@ -1,5 +1,10 @@
 package qb
 
+import (
+	"fmt"
+	"strings"
+)
+
 // SqliteDialect is a type of dialect that can be used with sqlite driver
 type SqliteDialect struct {
 	escaping bool
@@ -60,5 +65,31 @@ func (d *SqliteDialect) Driver() string {
 }
 
 func (d *SqliteDialect) GetCompiler() Compiler {
-	return SQLCompiler{d}
+	return SqliteCompiler{SQLCompiler{d}}
+}
+
+type SqliteCompiler struct {
+	SQLCompiler
+}
+
+// VisitUpsert generates the folowing sql: REPLACE INTO ... VALUES ...
+func (SqliteCompiler) VisitUpsert(context *CompilerContext, upsert UpsertStmt) string {
+	var (
+		colNames []string
+		values   []string
+	)
+	for k, v := range upsert.values {
+		colNames = append(colNames, context.Compiler.VisitLabel(context, k))
+		context.Binds = append(context.Binds, v)
+		values = append(values, context.Dialect.Placeholder())
+	}
+
+	sql := fmt.Sprintf(
+		"REPLACE INTO %s(%s)\nVALUES(%s)",
+		context.Compiler.VisitLabel(context, upsert.table.Name),
+		strings.Join(colNames, ", "),
+		strings.Join(values, ", "),
+	)
+
+	return sql
 }

--- a/dialect_sqlite.go
+++ b/dialect_sqlite.go
@@ -58,3 +58,7 @@ func (d *SqliteDialect) SupportsUnsigned() bool { return false }
 func (d *SqliteDialect) Driver() string {
 	return "sqlite3"
 }
+
+func (d *SqliteDialect) GetCompiler() Compiler {
+	return SQLCompiler{d}
+}

--- a/dialect_test.go
+++ b/dialect_test.go
@@ -22,6 +22,7 @@ func (suite *DialectTestSuite) SetupTest() {
 }
 
 func (suite *DialectTestSuite) TestDefaultDialect() {
+	assert.Implements(suite.T(), (*Compiler)(nil), suite.def.GetCompiler())
 	assert.Equal(suite.T(), false, suite.def.SupportsUnsigned())
 	assert.Equal(suite.T(), "test", suite.def.Escape("test"))
 	assert.Equal(suite.T(), false, suite.def.Escaping())

--- a/insert.go
+++ b/insert.go
@@ -51,15 +51,15 @@ func (s InsertStmt) Build(dialect Dialect) *Stmt {
 		statement.AddBinding(v)
 		values = append(values, dialect.Placeholder())
 	}
-	statement.AddClause(fmt.Sprintf("INSERT INTO %s(%s)", dialect.Escape(s.table.Name), strings.Join(colNames, ", ")))
-	statement.AddClause(fmt.Sprintf("VALUES(%s)", strings.Join(values, ", ")))
+	statement.AddSQLClause(fmt.Sprintf("INSERT INTO %s(%s)", dialect.Escape(s.table.Name), strings.Join(colNames, ", ")))
+	statement.AddSQLClause(fmt.Sprintf("VALUES(%s)", strings.Join(values, ", ")))
 
 	returning := []string{}
 	for _, r := range s.returning {
 		returning = append(returning, dialect.Escape(r.Name))
 	}
 	if len(s.returning) > 0 {
-		statement.AddClause(fmt.Sprintf("RETURNING %s", strings.Join(returning, ", ")))
+		statement.AddSQLClause(fmt.Sprintf("RETURNING %s", strings.Join(returning, ", ")))
 	}
 	return statement
 }

--- a/select.go
+++ b/select.go
@@ -23,7 +23,7 @@ type SelectStmt struct {
 	groupBy []ColumnElem
 	orderBy *OrderByClause
 	having  []HavingClause
-	where   *WhereSQLClause
+	where   *WhereClause
 	offset  *int
 	count   *int
 }
@@ -35,7 +35,7 @@ func (s SelectStmt) From(table TableElem) SelectStmt {
 }
 
 // Where sets the where clause of select statement
-func (s SelectStmt) Where(clause SQLClause) SelectStmt {
+func (s SelectStmt) Where(clause Clause) SelectStmt {
 	where := Where(clause)
 	s.where = &where
 	return s
@@ -140,9 +140,8 @@ func (s SelectStmt) Build(dialect Dialect) *Stmt {
 
 	// where
 	if s.where != nil {
-		where, bindings := s.where.Build(dialect)
+		where := s.where.Accept(context)
 		statement.AddSQLClause(where)
-		statement.AddBinding(bindings...)
 	}
 
 	// group by

--- a/select.go
+++ b/select.go
@@ -47,23 +47,23 @@ func (s SelectStmt) Where(clause Clause) SelectStmt {
 }
 
 // InnerJoin appends an inner join clause to the select statement
-func (s SelectStmt) InnerJoin(right Selectable, leftCol ColumnElem, rightCol ColumnElem) SelectStmt {
-	return s.From(join("INNER JOIN", s.from, right, leftCol, rightCol))
+func (s SelectStmt) InnerJoin(right Selectable, onClauses ...Clause) SelectStmt {
+	return s.From(Join("INNER JOIN", s.from, right, onClauses...))
 }
 
 // CrossJoin appends an cross join clause to the select statement
 func (s SelectStmt) CrossJoin(right Selectable) SelectStmt {
-	return s.From(join("CROSS JOIN", s.from, right, ColumnElem{}, ColumnElem{}))
+	return s.From(Join("CROSS JOIN", s.from, right, nil))
 }
 
 // LeftJoin appends an left outer join clause to the select statement
 func (s SelectStmt) LeftJoin(right Selectable, leftCol ColumnElem, rightCol ColumnElem) SelectStmt {
-	return s.From(join("LEFT OUTER JOIN", s.from, right, leftCol, rightCol))
+	return s.From(Join("LEFT OUTER JOIN", s.from, right, leftCol, rightCol))
 }
 
 // RightJoin appends a right outer join clause to select statement
 func (s SelectStmt) RightJoin(right Selectable, leftCol ColumnElem, rightCol ColumnElem) SelectStmt {
-	return s.From(join("RIGHT OUTER JOIN", s.from, right, leftCol, rightCol))
+	return s.From(Join("RIGHT OUTER JOIN", s.from, right, leftCol, rightCol))
 }
 
 // OrderBy generates an OrderByClause and sets select statement's orderbyclause
@@ -124,36 +124,116 @@ func (s SelectStmt) Build(dialect Dialect) *Stmt {
 	return statement
 }
 
-func join(joinType string, left Selectable, right Selectable, leftCol ColumnElem, rightCol ColumnElem) JoinClause {
+type joinOnClauseCandidate struct {
+	source TableElem
+	ref    Reference
+	target TableElem
+}
+
+// GuessJoinOnClause finds a join 'ON' clause between two tables
+func GuessJoinOnClause(left Selectable, right Selectable) Clause {
+	leftTable, ok := left.(TableElem)
+	if !ok {
+		panic("left Selectable is not a Table: Cannot guess join onClause")
+	}
+	rightTable, ok := right.(TableElem)
+	if !ok {
+		panic("right Selectable is not a Table: Cannot guess join onClause")
+	}
+
+	var candidates []joinOnClauseCandidate
+
+	for _, ref := range leftTable.ForeignKeyConstraints.Refs {
+		if ref.RefTable != rightTable.Name {
+			continue
+		}
+		candidates = append(
+			candidates,
+			joinOnClauseCandidate{leftTable, ref, rightTable})
+	}
+
+	for _, ref := range rightTable.ForeignKeyConstraints.Refs {
+		if ref.RefTable != leftTable.Name {
+			continue
+		}
+		candidates = append(
+			candidates,
+			joinOnClauseCandidate{rightTable, ref, leftTable})
+	}
+	switch len(candidates) {
+	case 0:
+		panic(fmt.Sprintf(
+			"No foreign keys found between %s and %s",
+			leftTable.Name, rightTable.Name))
+	case 1:
+		candidate := candidates[0]
+		var clauses []Clause
+		for i, col := range candidate.ref.Cols {
+			refCol := candidate.ref.RefCols[i]
+			clauses = append(
+				clauses,
+				Eq(candidate.source.C(col), candidate.target.C(refCol)),
+			)
+		}
+		if len(clauses) == 1 {
+			return clauses[0]
+		}
+		return And(clauses...)
+	default:
+		panic(fmt.Sprintf(
+			"Found %d foreign keys between %s and %s",
+			len(candidates), leftTable.Name, rightTable.Name))
+	}
+}
+
+// MakeJoinOnClause assemble a 'ON' clause for a join from either:
+// 0 clause: attempt to guess the join clause (only if left & right are tables),
+//           otherwise panics
+// 1 clause: returns it
+// 2 clauses: returns a Eq() of both
+// otherwise if panics
+func MakeJoinOnClause(left Selectable, right Selectable, onClause ...Clause) Clause {
+	switch len(onClause) {
+	case 0:
+		return GuessJoinOnClause(left, right)
+	case 1:
+		return onClause[0]
+	case 2:
+		return Eq(onClause[0], onClause[1])
+	default:
+		panic("Cannot make a join condition with more than 2 clauses")
+	}
+}
+
+func Join(joinType string, left Selectable, right Selectable, onClause ...Clause) JoinClause {
 	return JoinClause{
-		joinType,
-		left,
-		right,
-		leftCol,
-		rightCol,
+		JoinType: joinType,
+		Left:     left,
+		Right:    right,
+		OnClause: MakeJoinOnClause(left, right, onClause...),
 	}
 }
 
 // JoinClause is the base struct for generating join clauses when using select
 // It satisfies Clause interface
 type JoinClause struct {
-	joinType string
-	left     Selectable
-	right    Selectable
-	leftCol  ColumnElem
-	rightCol ColumnElem
+	JoinType string
+	Left     Selectable
+	Right    Selectable
+	OnClause Clause
 }
 
+// Accept calls the compiler VisitJoin method
 func (c JoinClause) Accept(context *CompilerContext) string {
 	return context.Compiler.VisitJoin(context, c)
 }
 
 func (c JoinClause) All() []Clause {
-	return append(c.left.All(), c.right.All()...)
+	return append(c.Left.All(), c.Right.All()...)
 }
 
 func (c JoinClause) ColumnList() []ColumnElem {
-	return append(c.left.ColumnList(), c.right.ColumnList()...)
+	return append(c.Left.ColumnList(), c.Right.ColumnList()...)
 }
 
 func (c JoinClause) C(name string) ColumnElem {

--- a/select.go
+++ b/select.go
@@ -107,13 +107,18 @@ func (s SelectStmt) Limit(offset int, count int) SelectStmt {
 	return s
 }
 
+// Accept calls the compiler VisitSelect method
+func (s SelectStmt) Accept(context *CompilerContext) string {
+	return context.Compiler.VisitSelect(context, s)
+}
+
 // Build compiles the select statement and returns the Stmt
 func (s SelectStmt) Build(dialect Dialect) *Stmt {
 	defer dialect.Reset()
 
 	context := NewCompilerContext(dialect)
 	statement := Statement()
-	statement.AddSQLClause(context.Compiler.VisitSelect(context, s))
+	statement.AddSQLClause(s.Accept(context))
 	statement.AddBinding(context.Binds...)
 
 	return statement

--- a/select_test.go
+++ b/select_test.go
@@ -143,6 +143,9 @@ func (suite *SelectTestSuite) TestJoin() {
 		InnerJoin(suite.users, suite.sessions.C("user_id"), suite.users.C("id")).
 		Where(Eq(suite.sessions.C("user_id"), 5))
 
+	assert.Equal(suite.T(), suite.sessions.C("user_id"), selInnerJoin.from.C("user_id"))
+	assert.Panics(suite.T(), func() { selInnerJoin.from.C("invalid") })
+
 	var statement *Stmt
 
 	statement = selInnerJoin.Build(suite.sqlite)

--- a/select_test.go
+++ b/select_test.go
@@ -68,15 +68,15 @@ func (suite *SelectTestSuite) TestSelectWhere() {
 	var statement *Stmt
 
 	statement = sel.Build(suite.sqlite)
-	assert.Equal(suite.T(), "SELECT id\nFROM users\nWHERE (users.email = ? AND users.id != ?);", statement.SQL())
+	assert.Equal(suite.T(), "SELECT id\nFROM users\nWHERE (email = ? AND id != ?);", statement.SQL())
 	assert.Equal(suite.T(), []interface{}{"al@pacino.com", 5}, statement.Bindings())
 
 	statement = sel.Build(suite.mysql)
-	assert.Equal(suite.T(), "SELECT `id`\nFROM `users`\nWHERE (`users`.`email` = ? AND `users`.`id` != ?);", statement.SQL())
+	assert.Equal(suite.T(), "SELECT `id`\nFROM `users`\nWHERE (`email` = ? AND `id` != ?);", statement.SQL())
 	assert.Equal(suite.T(), []interface{}{"al@pacino.com", 5}, statement.Bindings())
 
 	statement = sel.Build(suite.postgres)
-	assert.Equal(suite.T(), "SELECT \"id\"\nFROM \"users\"\nWHERE (\"users\".\"email\" = $1 AND \"users\".\"id\" != $2);", statement.SQL())
+	assert.Equal(suite.T(), "SELECT \"id\"\nFROM \"users\"\nWHERE (\"email\" = $1 AND \"id\" != $2);", statement.SQL())
 	assert.Equal(suite.T(), []interface{}{"al@pacino.com", 5}, statement.Bindings())
 }
 
@@ -89,15 +89,15 @@ func (suite *SelectTestSuite) TestOrderByLimit() {
 
 	var statement *Stmt
 	statement = selOrderByDesc.Build(suite.sqlite)
-	assert.Equal(suite.T(), "SELECT id\nFROM sessions\nWHERE sessions.user_id = ?\nORDER BY id DESC\nLIMIT 20 OFFSET 0;", statement.SQL())
+	assert.Equal(suite.T(), "SELECT id\nFROM sessions\nWHERE user_id = ?\nORDER BY id DESC\nLIMIT 20 OFFSET 0;", statement.SQL())
 	assert.Equal(suite.T(), []interface{}{5}, statement.Bindings())
 
 	statement = selOrderByDesc.Build(suite.mysql)
-	assert.Equal(suite.T(), "SELECT `id`\nFROM `sessions`\nWHERE `sessions`.`user_id` = ?\nORDER BY `id` DESC\nLIMIT 20 OFFSET 0;", statement.SQL())
+	assert.Equal(suite.T(), "SELECT `id`\nFROM `sessions`\nWHERE `user_id` = ?\nORDER BY `id` DESC\nLIMIT 20 OFFSET 0;", statement.SQL())
 	assert.Equal(suite.T(), []interface{}{5}, statement.Bindings())
 
 	statement = selOrderByDesc.Build(suite.postgres)
-	assert.Equal(suite.T(), "SELECT \"id\"\nFROM \"sessions\"\nWHERE \"sessions\".\"user_id\" = $1\nORDER BY \"id\" DESC\nLIMIT 20 OFFSET 0;", statement.SQL())
+	assert.Equal(suite.T(), "SELECT \"id\"\nFROM \"sessions\"\nWHERE \"user_id\" = $1\nORDER BY \"id\" DESC\nLIMIT 20 OFFSET 0;", statement.SQL())
 	assert.Equal(suite.T(), []interface{}{5}, statement.Bindings())
 
 	selWithoutOrder := Select(suite.sessions.C("id")).
@@ -106,15 +106,15 @@ func (suite *SelectTestSuite) TestOrderByLimit() {
 		OrderBy(suite.sessions.C("id"))
 
 	statement = selWithoutOrder.Build(suite.sqlite)
-	assert.Equal(suite.T(), "SELECT id\nFROM sessions\nWHERE sessions.user_id = ?\nORDER BY id ASC;", statement.SQL())
+	assert.Equal(suite.T(), "SELECT id\nFROM sessions\nWHERE user_id = ?\nORDER BY id ASC;", statement.SQL())
 	assert.Equal(suite.T(), []interface{}{5}, statement.Bindings())
 
 	statement = selWithoutOrder.Build(suite.mysql)
-	assert.Equal(suite.T(), "SELECT `id`\nFROM `sessions`\nWHERE `sessions`.`user_id` = ?\nORDER BY `id` ASC;", statement.SQL())
+	assert.Equal(suite.T(), "SELECT `id`\nFROM `sessions`\nWHERE `user_id` = ?\nORDER BY `id` ASC;", statement.SQL())
 	assert.Equal(suite.T(), []interface{}{5}, statement.Bindings())
 
 	statement = selWithoutOrder.Build(suite.postgres)
-	assert.Equal(suite.T(), "SELECT \"id\"\nFROM \"sessions\"\nWHERE \"sessions\".\"user_id\" = $1\nORDER BY \"id\" ASC;", statement.SQL())
+	assert.Equal(suite.T(), "SELECT \"id\"\nFROM \"sessions\"\nWHERE \"user_id\" = $1\nORDER BY \"id\" ASC;", statement.SQL())
 	assert.Equal(suite.T(), []interface{}{5}, statement.Bindings())
 
 	selOrderByAsc := Select(suite.sessions.C("id")).
@@ -123,15 +123,15 @@ func (suite *SelectTestSuite) TestOrderByLimit() {
 		OrderBy(suite.sessions.C("id")).Asc()
 
 	statement = selOrderByAsc.Build(suite.sqlite)
-	assert.Equal(suite.T(), "SELECT id\nFROM sessions\nWHERE sessions.user_id = ?\nORDER BY id ASC;", statement.SQL())
+	assert.Equal(suite.T(), "SELECT id\nFROM sessions\nWHERE user_id = ?\nORDER BY id ASC;", statement.SQL())
 	assert.Equal(suite.T(), []interface{}{5}, statement.Bindings())
 
 	statement = selOrderByAsc.Build(suite.mysql)
-	assert.Equal(suite.T(), "SELECT `id`\nFROM `sessions`\nWHERE `sessions`.`user_id` = ?\nORDER BY `id` ASC;", statement.SQL())
+	assert.Equal(suite.T(), "SELECT `id`\nFROM `sessions`\nWHERE `user_id` = ?\nORDER BY `id` ASC;", statement.SQL())
 	assert.Equal(suite.T(), []interface{}{5}, statement.Bindings())
 
 	statement = selOrderByAsc.Build(suite.postgres)
-	assert.Equal(suite.T(), "SELECT \"id\"\nFROM \"sessions\"\nWHERE \"sessions\".\"user_id\" = $1\nORDER BY \"id\" ASC;", statement.SQL())
+	assert.Equal(suite.T(), "SELECT \"id\"\nFROM \"sessions\"\nWHERE \"user_id\" = $1\nORDER BY \"id\" ASC;", statement.SQL())
 	assert.Equal(suite.T(), []interface{}{5}, statement.Bindings())
 }
 

--- a/select_test.go
+++ b/select_test.go
@@ -146,6 +146,8 @@ func (suite *SelectTestSuite) TestJoin() {
 	assert.Equal(suite.T(), suite.sessions.C("user_id"), selInnerJoin.from.C("user_id"))
 	assert.Panics(suite.T(), func() { selInnerJoin.from.C("invalid") })
 
+	assert.Equal(suite.T(), len(suite.sessions.All())+len(suite.users.All()), len(selInnerJoin.from.All()))
+
 	var statement *Stmt
 
 	statement = selInnerJoin.Build(suite.sqlite)
@@ -233,6 +235,30 @@ func (suite *SelectTestSuite) TestGroupByHaving() {
 	statement = sel.Build(suite.postgres)
 	assert.Equal(suite.T(), "SELECT COUNT(\"id\")\nFROM \"sessions\"\nGROUP BY \"user_id\"\nHAVING SUM(\"id\") > $1;", statement.SQL())
 	assert.Equal(suite.T(), []interface{}{4}, statement.Bindings())
+}
+
+func (suite *SelectTestSuite) TestAlias() {
+	sessionA := Alias("newname", suite.sessions)
+	sel := Select(sessionA.C("id")).From(sessionA)
+	st := sel.Build(suite.sqlite)
+	assert.Equal(suite.T(), "SELECT id\nFROM sessions AS newname;", st.SQL())
+
+	sel = Select(sessionA.All()...).From(sessionA)
+	sql := sel.Build(suite.mysql).SQL()
+	assert.Contains(suite.T(), sql, "`id`", st.SQL())
+	assert.Contains(suite.T(), sql, "`user_id`", st.SQL())
+	assert.Contains(suite.T(), sql, "`auth_token`", st.SQL())
+
+	usersA := Alias("u", suite.users)
+	sel = Select(usersA.C("email")).
+		From(usersA).
+		LeftJoin(sessionA, usersA.C("id"), sessionA.C("user_id")).
+		Where(sessionA.C("auth_token").Eq("42"))
+	st = sel.Build(suite.postgres)
+	assert.Equal(suite.T(), `SELECT "u"."email"
+FROM "users" AS "u"
+LEFT OUTER JOIN "sessions" AS "newname" ON "u"."id" = "newname"."user_id"
+WHERE "newname"."auth_token" = $1;`, st.SQL())
 }
 
 func TestSelectTestSuite(t *testing.T) {

--- a/session.go
+++ b/session.go
@@ -172,7 +172,7 @@ func (s *Session) Find(model interface{}) *Session {
 	table := s.mapper.ModelName(model)
 	modelMap := s.mapper.ToMap(model, true)
 
-	cols := []SQLClause{}
+	cols := []Clause{}
 	for k := range modelMap {
 		cols = append(cols, s.T(table).C(k))
 	}
@@ -210,7 +210,7 @@ func (s *Session) Statement() *Stmt {
 }
 
 // Query starts a select statement given columns
-func (s *Session) Query(clauses ...SQLClause) *Session {
+func (s *Session) Query(clauses ...Clause) *Session {
 	if len(clauses) == 0 {
 		panic(fmt.Errorf("You must enter one or more column or aggregate paramater(s)"))
 	} else {
@@ -229,7 +229,7 @@ func (s *Session) Query(clauses ...SQLClause) *Session {
 }
 
 // isCol returns if the clause is ColumnElem type
-func (s *Session) isCol(clause SQLClause) bool {
+func (s *Session) isCol(clause Clause) bool {
 	switch clause.(type) {
 	case ColumnElem:
 		return true
@@ -323,7 +323,7 @@ func (s *Session) GroupBy(cols ...ColumnElem) *Session {
 }
 
 // Having wraps the select's Having
-func (s *Session) Having(aggregate AggregateSQLClause, op string, value interface{}) *Session {
+func (s *Session) Having(aggregate AggregateClause, op string, value interface{}) *Session {
 	if !s.isSelect() {
 		panic(fmt.Errorf("Please use Query(cols ...ColumnElem) before calling Having()"))
 	}

--- a/session.go
+++ b/session.go
@@ -31,7 +31,7 @@ func New(driver string, dsn string) (*Session, error) {
 // Session is the composition of engine connection & orm mappings
 type Session struct {
 	builder    Builder
-	filters    []SQLClause
+	filters    []Clause
 	statements []*Stmt
 	engine     *Engine
 	mapper     MapperElem
@@ -114,7 +114,7 @@ func (s *Session) Delete(model interface{}) {
 	tableName := s.mapper.ModelName(model)
 
 	d := Delete(s.metadata.Table(tableName))
-	conditions := []SQLClause{}
+	conditions := []Clause{}
 	for k, v := range kv {
 		conditions = append(conditions, Eq(s.metadata.Table(tableName).C(k), v))
 	}
@@ -177,7 +177,7 @@ func (s *Session) Find(model interface{}) *Session {
 		cols = append(cols, s.T(table).C(k))
 	}
 
-	ands := []SQLClause{}
+	ands := []Clause{}
 
 	for k := range modelMap {
 		if modelMap[k] == nil {
@@ -204,7 +204,7 @@ func (s *Session) Statement() *Stmt {
 	}
 
 	statement := s.builder.Build(s.dialect)
-	s.filters = []SQLClause{}
+	s.filters = []Clause{}
 	s.builder = nil
 	return statement
 }
@@ -251,7 +251,7 @@ func (s *Session) isSelect() bool {
 // Filter appends a filter to the current select statement
 // NOTE: It currently only builds AndSQLClause within the filters
 // TODO: Add OR able filters
-func (s *Session) Filter(conditional SQLClause) *Session {
+func (s *Session) Filter(conditional Clause) *Session {
 	if !s.isSelect() {
 		panic(fmt.Errorf("Please use Query(cols ...ColumnElem) before calling Filter()"))
 	}

--- a/session_test.go
+++ b/session_test.go
@@ -148,10 +148,11 @@ func TestSessionWrappings(t *testing.T) {
 
 	selAggAvgSum := qb.
 		Query(Avg(users.C("score")), Sum(users.C("score"))).
+		From(users).
 		GroupBy(users.C("id")).
 		Statement()
 
-	assert.Equal(t, "SELECT AVG(score), SUM(score)\nFROM \nGROUP BY id;", selAggAvgSum.SQL())
+	assert.Equal(t, "SELECT AVG(score), SUM(score)\nFROM users\nGROUP BY id;", selAggAvgSum.SQL())
 	assert.Equal(t, []interface{}{}, selAggAvgSum.Bindings())
 
 	assert.Panics(t, func() {

--- a/session_test.go
+++ b/session_test.go
@@ -133,8 +133,8 @@ func TestSessionWrappings(t *testing.T) {
 		Filter(users.C("name").Like("%Robert%")).
 		Statement()
 
-	assert.Equal(t, "SELECT id, name\nFROM users\nWHERE (name LIKE '%Robert%');", selLike.SQL())
-	assert.Equal(t, []interface{}{}, selLike.Bindings())
+	assert.Equal(t, "SELECT id, name\nFROM users\nWHERE (name LIKE $1);", selLike.SQL())
+	assert.Equal(t, []interface{}{"%Robert%"}, selLike.Bindings())
 
 	selAggCountMinMax := qb.
 		Query(Count(users.C("id")), Max(users.C("name")), Min(users.C("name"))).

--- a/session_test.go
+++ b/session_test.go
@@ -133,7 +133,7 @@ func TestSessionWrappings(t *testing.T) {
 		Filter(users.C("name").Like("%Robert%")).
 		Statement()
 
-	assert.Equal(t, "SELECT id, name\nFROM users\nWHERE (users.name LIKE '%Robert%');", selLike.SQL())
+	assert.Equal(t, "SELECT id, name\nFROM users\nWHERE (name LIKE '%Robert%');", selLike.SQL())
 	assert.Equal(t, []interface{}{}, selLike.Bindings())
 
 	selAggCountMinMax := qb.

--- a/session_test.go
+++ b/session_test.go
@@ -104,7 +104,7 @@ func TestSessionWrappings(t *testing.T) {
 	assert.Contains(t, selLeftJoin.SQL(), "id")
 	assert.Contains(t, selLeftJoin.SQL(), "user_id")
 	assert.Contains(t, selLeftJoin.SQL(), "created_at")
-	assert.Contains(t, selLeftJoin.SQL(), "\nFROM sessions\nLEFT OUTER JOIN users ON sessions.user_id = users.id\nWHERE (sessions.user_id = $1 AND sessions.user_id != $2 AND sessions.created_at <= $3 AND sessions.created_at < $4 AND sessions.created_at >= $5 AND sessions.created_at > $6)\nORDER BY created_at DESC\nLIMIT 20 OFFSET 0;")
+	assert.Contains(t, selLeftJoin.SQL(), "\nFROM sessions\nLEFT OUTER JOIN users ON sessions.user_id = users.id\nWHERE (sessions.user_id = $1 AND sessions.user_id != $2 AND sessions.created_at <= $3 AND sessions.created_at < $4 AND sessions.created_at >= $5 AND sessions.created_at > $6)\nORDER BY sessions.created_at DESC\nLIMIT 20 OFFSET 0;")
 	assert.Equal(t, []interface{}{"9efbc9ab-7914-426c-8818-7d40b0427c8f", "9efbc9ac-7914-426c-8818-7d40b0427c8f", "2016-06-10", "2016-06-10", "2016-06-09", "2016-06-09"}, selLeftJoin.Bindings())
 
 	selRightJoin := qb.Query(sessions.C("id"), sessions.C("user_id"), sessions.C("created_at")).
@@ -114,7 +114,7 @@ func TestSessionWrappings(t *testing.T) {
 		Filter(sessions.C("user_id").In("9efbc9ab-7914-426c-8818-7d40b0427c8f")).
 		Statement()
 
-	assert.Equal(t, "SELECT sessions.id, sessions.user_id, sessions.created_at\nFROM sessions\nRIGHT OUTER JOIN users ON sessions.user_id = users.id\nWHERE (sessions.user_id IN ($1))\nORDER BY created_at DESC\nLIMIT 20 OFFSET 0;", selRightJoin.SQL())
+	assert.Equal(t, "SELECT sessions.id, sessions.user_id, sessions.created_at\nFROM sessions\nRIGHT OUTER JOIN users ON sessions.user_id = users.id\nWHERE (sessions.user_id IN ($1))\nORDER BY sessions.created_at DESC\nLIMIT 20 OFFSET 0;", selRightJoin.SQL())
 	assert.Equal(t, []interface{}{"9efbc9ab-7914-426c-8818-7d40b0427c8f"}, selRightJoin.Bindings())
 
 	selCrossJoin := qb.
@@ -125,7 +125,7 @@ func TestSessionWrappings(t *testing.T) {
 		Filter(sessions.C("user_id").NotIn("9efbc9ab-7914-426c-8818-7d40b0427c8f")).
 		Statement()
 
-	assert.Equal(t, "SELECT sessions.id, sessions.user_id, sessions.created_at\nFROM sessions\nCROSS JOIN users\nWHERE (sessions.user_id NOT IN ($1))\nORDER BY created_at ASC\nLIMIT 20 OFFSET 0;", selCrossJoin.SQL())
+	assert.Equal(t, "SELECT sessions.id, sessions.user_id, sessions.created_at\nFROM sessions\nCROSS JOIN users\nWHERE (sessions.user_id NOT IN ($1))\nORDER BY sessions.created_at ASC\nLIMIT 20 OFFSET 0;", selCrossJoin.SQL())
 	assert.Equal(t, []interface{}{"9efbc9ab-7914-426c-8818-7d40b0427c8f"}, selCrossJoin.Bindings())
 
 	selLike := qb.

--- a/statement.go
+++ b/statement.go
@@ -42,8 +42,8 @@ func (s *Stmt) SetDelimiter(delimiter string) {
 	s.delimiter = delimiter
 }
 
-// AddClause appends a new clause to current query
-func (s *Stmt) AddClause(clause string) {
+// AddSQLClause appends a new clause to current query
+func (s *Stmt) AddSQLClause(clause string) {
 	s.clauses = append(s.clauses, clause)
 }
 
@@ -54,8 +54,8 @@ func (s *Stmt) AddBinding(bindings ...interface{}) {
 	}
 }
 
-// Clauses returns all clauses of current query
-func (s *Stmt) Clauses() []string {
+// SQLClauses returns all clauses of current query
+func (s *Stmt) SQLClauses() []string {
 	return s.clauses
 }
 

--- a/statement_test.go
+++ b/statement_test.go
@@ -8,12 +8,12 @@ import (
 func TestStatement(t *testing.T) {
 	statement := Statement()
 
-	statement.AddClause("SELECT name")
-	statement.AddClause("FROM user")
-	statement.AddClause("WHERE id = ?")
+	statement.AddSQLClause("SELECT name")
+	statement.AddSQLClause("FROM user")
+	statement.AddSQLClause("WHERE id = ?")
 	statement.AddBinding(5)
 
-	assert.Equal(t, []string{"SELECT name", "FROM user", "WHERE id = ?"}, statement.Clauses())
+	assert.Equal(t, []string{"SELECT name", "FROM user", "WHERE id = ?"}, statement.SQLClauses())
 	assert.Equal(t, []interface{}{5}, statement.Bindings())
 	assert.Equal(t, "SELECT name\nFROM user\nWHERE id = ?;", statement.SQL())
 }
@@ -27,7 +27,7 @@ func TestStatementRaw(t *testing.T) {
 		WHERE id = ?;
 		`
 	statement.Text(sql)
-	assert.Equal(t, []string{"SELECT name", "FROM user", "WHERE id = ?"}, statement.Clauses())
+	assert.Equal(t, []string{"SELECT name", "FROM user", "WHERE id = ?"}, statement.SQLClauses())
 	assert.Equal(t, "SELECT name\nFROM user\nWHERE id = ?;", statement.SQL())
 }
 
@@ -38,13 +38,13 @@ func TestStatementWithCustomDelimiter(t *testing.T) {
 
 	statement.SetDelimiter(" ")
 
-	statement.AddClause("SELECT name")
-	statement.AddClause("FROM user")
+	statement.AddSQLClause("SELECT name")
+	statement.AddSQLClause("FROM user")
 
-	statement.AddClause("WHERE id = ?")
+	statement.AddSQLClause("WHERE id = ?")
 	statement.AddBinding(5)
 
-	assert.Equal(t, []string{"SELECT name", "FROM user", "WHERE id = ?"}, statement.Clauses())
+	assert.Equal(t, []string{"SELECT name", "FROM user", "WHERE id = ?"}, statement.SQLClauses())
 	assert.Equal(t, []interface{}{5}, statement.Bindings())
 	assert.Equal(t, "SELECT name FROM user WHERE id = ?;", statement.SQL())
 }

--- a/table.go
+++ b/table.go
@@ -79,6 +79,14 @@ func (t TableElem) All() []Clause {
 	return cols
 }
 
+func (t TableElem) ColumnList() []ColumnElem {
+	cols := []ColumnElem{}
+	for _, v := range t.Columns {
+		cols = append(cols, v)
+	}
+	return cols
+}
+
 // Index appends an IndexElem to current table without giving table name
 func (t TableElem) Index(cols ...string) TableElem {
 	t.Indices = append(t.Indices, Index(t.Name, cols...))

--- a/table.go
+++ b/table.go
@@ -65,6 +65,11 @@ type TableElem struct {
 	Indices               []IndexElem
 }
 
+// DefaultName returns the name of the table
+func (t TableElem) DefaultName() string {
+	return t.Name
+}
+
 // All returns all columns of table as a column slice
 func (t TableElem) All() []Clause {
 	cols := []Clause{}

--- a/table.go
+++ b/table.go
@@ -176,3 +176,8 @@ func (t TableElem) Upsert() UpsertStmt {
 func (t TableElem) Select(clauses ...Clause) SelectStmt {
 	return Select(clauses...).From(t)
 }
+
+// Accept implements Clause.Accept
+func (t TableElem) Accept(context *CompilerContext) string {
+	return context.Compiler.VisitTable(context, t)
+}

--- a/table.go
+++ b/table.go
@@ -66,8 +66,8 @@ type TableElem struct {
 }
 
 // All returns all columns of table as a column slice
-func (t TableElem) All() []SQLClause {
-	cols := []SQLClause{}
+func (t TableElem) All() []Clause {
+	cols := []Clause{}
 	for _, v := range t.Columns {
 		cols = append(cols, v)
 	}
@@ -173,6 +173,6 @@ func (t TableElem) Upsert() UpsertStmt {
 }
 
 // Select starts a select statement by setting from table
-func (t TableElem) Select(clauses ...SQLClause) SelectStmt {
+func (t TableElem) Select(clauses ...Clause) SelectStmt {
 	return Select(clauses...).From(t)
 }

--- a/table_test.go
+++ b/table_test.go
@@ -183,7 +183,7 @@ func (suite *TableTestSuite) TestTableStarters() {
 		Where(users.C("id").Eq("5a73ef89-cf0a-4c51-ab8c-cc273ebb3a55")).
 		Build(sqlite)
 
-	assert.Equal(suite.T(), "SELECT id, email\nFROM users\nWHERE users.id = ?;", sel.SQL())
+	assert.Equal(suite.T(), "SELECT id, email\nFROM users\nWHERE id = ?;", sel.SQL())
 	assert.Equal(suite.T(), []interface{}{"5a73ef89-cf0a-4c51-ab8c-cc273ebb3a55"}, sel.Bindings())
 }
 

--- a/update.go
+++ b/update.go
@@ -1,10 +1,5 @@
 package qb
 
-import (
-	"fmt"
-	"strings"
-)
-
 // Update generates an update statement and returns it
 // qb.Update(usersTable).
 // Values(map[string]interface{}{"id": 1}).
@@ -25,41 +20,19 @@ type UpdateStmt struct {
 	where     *WhereClause
 }
 
+// Accept implements Clause.Accept
+func (s UpdateStmt) Accept(context *CompilerContext) string {
+	return context.Compiler.VisitUpdate(context, s)
+}
+
 // Build generates a statement out of UpdateStmt object
 func (s UpdateStmt) Build(dialect Dialect) *Stmt {
 	defer dialect.Reset()
 
 	context := NewCompilerContext(dialect)
-
 	statement := Statement()
-	statement.AddSQLClause(fmt.Sprintf("UPDATE %s", dialect.Escape(s.table.Name)))
-	sets := []string{}
-	bindings := []interface{}{}
-	for k, v := range s.values {
-		sets = append(sets, fmt.Sprintf("%s = %s", dialect.Escape(k), dialect.Placeholder()))
-		bindings = append(bindings, v)
-	}
-
-	if len(sets) > 0 {
-		statement.AddSQLClause(fmt.Sprintf("SET %s", strings.Join(sets, ", ")))
-	}
-
-	if s.where != nil {
-		where := s.where.Accept(context)
-		statement.AddSQLClause(where)
-	}
-	bindings = append(bindings, context.Binds...)
-
-	returning := []string{}
-	for _, c := range s.returning {
-		returning = append(returning, dialect.Escape(c.Name))
-	}
-
-	if len(returning) > 0 {
-		statement.AddSQLClause(fmt.Sprintf("RETURNING %s", strings.Join(returning, ", ")))
-	}
-
-	statement.AddBinding(bindings...)
+	statement.AddSQLClause(s.Accept(context))
+	statement.AddBinding(context.Binds...)
 
 	return statement
 }

--- a/update.go
+++ b/update.go
@@ -22,7 +22,7 @@ type UpdateStmt struct {
 	table     TableElem
 	values    map[string]interface{}
 	returning []ColumnElem
-	where     *WhereClause
+	where     *WhereSQLClause
 }
 
 // Build generates a statement out of UpdateStmt object
@@ -30,7 +30,7 @@ func (s UpdateStmt) Build(dialect Dialect) *Stmt {
 	defer dialect.Reset()
 
 	statement := Statement()
-	statement.AddClause(fmt.Sprintf("UPDATE %s", dialect.Escape(s.table.Name)))
+	statement.AddSQLClause(fmt.Sprintf("UPDATE %s", dialect.Escape(s.table.Name)))
 	sets := []string{}
 	bindings := []interface{}{}
 	for k, v := range s.values {
@@ -39,13 +39,13 @@ func (s UpdateStmt) Build(dialect Dialect) *Stmt {
 	}
 
 	if len(sets) > 0 {
-		statement.AddClause(fmt.Sprintf("SET %s", strings.Join(sets, ", ")))
+		statement.AddSQLClause(fmt.Sprintf("SET %s", strings.Join(sets, ", ")))
 	}
 
 	if s.where != nil {
 		where, whereBindings := s.where.Build(dialect)
 		bindings = append(bindings, whereBindings...)
-		statement.AddClause(where)
+		statement.AddSQLClause(where)
 	}
 
 	returning := []string{}
@@ -54,7 +54,7 @@ func (s UpdateStmt) Build(dialect Dialect) *Stmt {
 	}
 
 	if len(returning) > 0 {
-		statement.AddClause(fmt.Sprintf("RETURNING %s", strings.Join(returning, ", ")))
+		statement.AddSQLClause(fmt.Sprintf("RETURNING %s", strings.Join(returning, ", ")))
 	}
 
 	statement.AddBinding(bindings...)
@@ -80,7 +80,7 @@ func (s UpdateStmt) Returning(cols ...ColumnElem) UpdateStmt {
 }
 
 // Where adds a where clause to update statement and returns the update statement
-func (s UpdateStmt) Where(clause Clause) UpdateStmt {
-	s.where = &WhereClause{clause}
+func (s UpdateStmt) Where(clause SQLClause) UpdateStmt {
+	s.where = &WhereSQLClause{clause}
 	return s
 }

--- a/upsert.go
+++ b/upsert.go
@@ -1,10 +1,5 @@
 package qb
 
-import (
-	"fmt"
-	"strings"
-)
-
 // Upsert generates an insert ... on (duplicate key/conflict) update statement
 func Upsert(table TableElem) UpsertStmt {
 	return UpsertStmt{
@@ -38,60 +33,18 @@ func (s UpsertStmt) Returning(cols ...ColumnElem) UpsertStmt {
 	return s
 }
 
+func (s UpsertStmt) Accept(context *CompilerContext) string {
+	return context.Compiler.VisitUpsert(context, s)
+}
+
 // Build generates a statement out of UpdateStmt object
-// NOTE: It generates different statements for each driver
-// For sqlite, it generates REPLACE INTO ... VALUES ...
-// For mysql, it generates INSERT INTO ... VALUES ... ON DUPLICATE KEY UPDATE ...
-// For postgres, it generates INSERT INTO ... VALUES ... ON CONFLICT(...) DO UPDATE SET ...
 func (s UpsertStmt) Build(dialect Dialect) *Stmt {
 	defer dialect.Reset()
 
+	context := NewCompilerContext(dialect)
 	statement := Statement()
+	statement.AddSQLClause(s.Accept(context))
+	statement.AddBinding(context.Binds...)
 
-	colNames := []string{}
-	values := []string{}
-	for k, v := range s.values {
-		colNames = append(colNames, dialect.Escape(k))
-		statement.AddBinding(v)
-		values = append(values, dialect.Placeholder())
-	}
-
-	switch dialect.Driver() {
-	case "mysql":
-		updates := []string{}
-		for k, v := range s.values {
-			updates = append(updates, fmt.Sprintf("%s = %s", dialect.Escape(k), dialect.Placeholder()))
-			statement.AddBinding(v)
-		}
-		statement.AddSQLClause(fmt.Sprintf("INSERT INTO %s(%s)", dialect.Escape(s.table.Name), strings.Join(colNames, ", ")))
-		statement.AddSQLClause(fmt.Sprintf("VALUES(%s)", strings.Join(values, ", ")))
-		statement.AddSQLClause(fmt.Sprintf("ON DUPLICATE KEY UPDATE %s", strings.Join(updates, ", ")))
-		break
-	case "postgres":
-		updates := []string{}
-		for k, v := range s.values {
-			updates = append(updates, fmt.Sprintf("%s = %s", dialect.Escape(k), dialect.Placeholder()))
-			statement.AddBinding(v)
-		}
-		statement.AddSQLClause(fmt.Sprintf("INSERT INTO %s(%s)", dialect.Escape(s.table.Name), strings.Join(colNames, ", ")))
-		statement.AddSQLClause(fmt.Sprintf("VALUES(%s)", strings.Join(values, ", ")))
-		uniqueCols := []string{}
-		for _, c := range s.table.PrimaryCols() {
-			uniqueCols = append(uniqueCols, dialect.Escape(c.Name))
-		}
-		statement.AddSQLClause(fmt.Sprintf("ON CONFLICT (%s) DO UPDATE SET %s", strings.Join(uniqueCols, ", "), strings.Join(updates, ", ")))
-		returning := []string{}
-		for _, r := range s.returning {
-			returning = append(returning, dialect.Escape(r.Name))
-		}
-		if len(s.returning) > 0 {
-			statement.AddSQLClause(fmt.Sprintf("RETURNING %s", strings.Join(returning, ", ")))
-		}
-		break
-	case "sqlite3":
-		statement.AddSQLClause(fmt.Sprintf("REPLACE INTO %s(%s)", dialect.Escape(s.table.Name), strings.Join(colNames, ", ")))
-		statement.AddSQLClause(fmt.Sprintf("VALUES(%s)", strings.Join(values, ", ")))
-		break
-	}
 	return statement
 }

--- a/upsert.go
+++ b/upsert.go
@@ -63,9 +63,9 @@ func (s UpsertStmt) Build(dialect Dialect) *Stmt {
 			updates = append(updates, fmt.Sprintf("%s = %s", dialect.Escape(k), dialect.Placeholder()))
 			statement.AddBinding(v)
 		}
-		statement.AddClause(fmt.Sprintf("INSERT INTO %s(%s)", dialect.Escape(s.table.Name), strings.Join(colNames, ", ")))
-		statement.AddClause(fmt.Sprintf("VALUES(%s)", strings.Join(values, ", ")))
-		statement.AddClause(fmt.Sprintf("ON DUPLICATE KEY UPDATE %s", strings.Join(updates, ", ")))
+		statement.AddSQLClause(fmt.Sprintf("INSERT INTO %s(%s)", dialect.Escape(s.table.Name), strings.Join(colNames, ", ")))
+		statement.AddSQLClause(fmt.Sprintf("VALUES(%s)", strings.Join(values, ", ")))
+		statement.AddSQLClause(fmt.Sprintf("ON DUPLICATE KEY UPDATE %s", strings.Join(updates, ", ")))
 		break
 	case "postgres":
 		updates := []string{}
@@ -73,24 +73,24 @@ func (s UpsertStmt) Build(dialect Dialect) *Stmt {
 			updates = append(updates, fmt.Sprintf("%s = %s", dialect.Escape(k), dialect.Placeholder()))
 			statement.AddBinding(v)
 		}
-		statement.AddClause(fmt.Sprintf("INSERT INTO %s(%s)", dialect.Escape(s.table.Name), strings.Join(colNames, ", ")))
-		statement.AddClause(fmt.Sprintf("VALUES(%s)", strings.Join(values, ", ")))
+		statement.AddSQLClause(fmt.Sprintf("INSERT INTO %s(%s)", dialect.Escape(s.table.Name), strings.Join(colNames, ", ")))
+		statement.AddSQLClause(fmt.Sprintf("VALUES(%s)", strings.Join(values, ", ")))
 		uniqueCols := []string{}
 		for _, c := range s.table.PrimaryCols() {
 			uniqueCols = append(uniqueCols, dialect.Escape(c.Name))
 		}
-		statement.AddClause(fmt.Sprintf("ON CONFLICT (%s) DO UPDATE SET %s", strings.Join(uniqueCols, ", "), strings.Join(updates, ", ")))
+		statement.AddSQLClause(fmt.Sprintf("ON CONFLICT (%s) DO UPDATE SET %s", strings.Join(uniqueCols, ", "), strings.Join(updates, ", ")))
 		returning := []string{}
 		for _, r := range s.returning {
 			returning = append(returning, dialect.Escape(r.Name))
 		}
 		if len(s.returning) > 0 {
-			statement.AddClause(fmt.Sprintf("RETURNING %s", strings.Join(returning, ", ")))
+			statement.AddSQLClause(fmt.Sprintf("RETURNING %s", strings.Join(returning, ", ")))
 		}
 		break
 	case "sqlite3":
-		statement.AddClause(fmt.Sprintf("REPLACE INTO %s(%s)", dialect.Escape(s.table.Name), strings.Join(colNames, ", ")))
-		statement.AddClause(fmt.Sprintf("VALUES(%s)", strings.Join(values, ", ")))
+		statement.AddSQLClause(fmt.Sprintf("REPLACE INTO %s(%s)", dialect.Escape(s.table.Name), strings.Join(colNames, ", ")))
+		statement.AddSQLClause(fmt.Sprintf("VALUES(%s)", strings.Join(values, ", ")))
 		break
 	}
 	return statement

--- a/upsert_test.go
+++ b/upsert_test.go
@@ -16,6 +16,8 @@ func TestUpsert(t *testing.T) {
 	postgres := NewDialect("postgres")
 	postgres.SetEscaping(true)
 
+	def := NewDialect("default")
+
 	users := Table(
 		"users",
 		Column("id", Varchar().Size(36)),
@@ -32,6 +34,10 @@ func TestUpsert(t *testing.T) {
 		"id":         "9883cf81-3b56-4151-ae4e-3903c5bc436d",
 		"email":      "al@pacino.com",
 		"created_at": now,
+	})
+
+	assert.Panics(t, func() {
+		ups.Build(def)
 	})
 
 	statement = ups.Build(sqlite)

--- a/where.go
+++ b/where.go
@@ -1,21 +1,16 @@
 package qb
 
-import (
-	"fmt"
-)
-
 // Where generates a compilable where clause
-func Where(clause SQLClause) WhereSQLClause {
-	return WhereSQLClause{clause}
+func Where(clause Clause) WhereClause {
+	return WhereClause{clause}
 }
 
-// WhereSQLClause is the base of any where clause when using expression api
-type WhereSQLClause struct {
-	clause SQLClause
+// WhereClause is the base of any where clause when using expression api
+type WhereClause struct {
+	clause Clause
 }
 
-// Build compiles the where clause, returns sql and bindings
-func (c WhereSQLClause) Build(dialect Dialect) (string, []interface{}) {
-	sql, bindings := c.clause.Build(dialect)
-	return fmt.Sprintf("WHERE %s", sql), bindings
+// Accept compiles the where clause, returns sql
+func (c WhereClause) Accept(context *CompilerContext) string {
+	return context.Compiler.VisitWhere(context, c)
 }

--- a/where.go
+++ b/where.go
@@ -5,17 +5,17 @@ import (
 )
 
 // Where generates a compilable where clause
-func Where(clause Clause) WhereClause {
-	return WhereClause{clause}
+func Where(clause SQLClause) WhereSQLClause {
+	return WhereSQLClause{clause}
 }
 
-// WhereClause is the base of any where clause when using expression api
-type WhereClause struct {
-	clause Clause
+// WhereSQLClause is the base of any where clause when using expression api
+type WhereSQLClause struct {
+	clause SQLClause
 }
 
 // Build compiles the where clause, returns sql and bindings
-func (c WhereClause) Build(dialect Dialect) (string, []interface{}) {
+func (c WhereSQLClause) Build(dialect Dialect) (string, []interface{}) {
 	sql, bindings := c.clause.Build(dialect)
 	return fmt.Sprintf("WHERE %s", sql), bindings
 }


### PR DESCRIPTION
Refactor the SQL compiling using a visitor pattern

The sql is now produced by a compiler provided by the dialect.
This way, a dialect can easily override parts of a compiler.

This new design will simplify a lot the implementation of aliases, and EXISTS.

edit: The branch contains working support for Alias()