### PR TITLE
Rename St(e) to Lt(e)

### DIFF
--- a/column.go
+++ b/column.go
@@ -86,9 +86,9 @@ func (c ColumnElem) Gt(value interface{}) Clause {
 	return Gt(c, value)
 }
 
-// St wraps the St(col ColumnElem, value interface{})
-func (c ColumnElem) St(value interface{}) Clause {
-	return St(c, value)
+// Lt wraps the Lt(col ColumnElem, value interface{})
+func (c ColumnElem) Lt(value interface{}) Clause {
+	return Lt(c, value)
 }
 
 // Gte wraps the Gte(col ColumnElem, value interface{})
@@ -96,7 +96,7 @@ func (c ColumnElem) Gte(value interface{}) Clause {
 	return Gte(c, value)
 }
 
-// Ste wraps the Ste(col ColumnElem, value interface{})
-func (c ColumnElem) Ste(value interface{}) Clause {
-	return Ste(c, value)
+// Lte wraps the Lte(col ColumnElem, value interface{})
+func (c ColumnElem) Lte(value interface{}) Clause {
+	return Lte(c, value)
 }

--- a/conditional.go
+++ b/conditional.go
@@ -37,8 +37,8 @@ func Gt(col ColumnElem, value interface{}) Conditional {
 	return Condition(col, ">", value)
 }
 
-// St generates a smaller than conditional sql clause
-func St(col ColumnElem, value interface{}) Conditional {
+// Lt generates a less than conditional sql clause
+func Lt(col ColumnElem, value interface{}) Conditional {
 	return Condition(col, "<", value)
 }
 
@@ -47,8 +47,8 @@ func Gte(col ColumnElem, value interface{}) Conditional {
 	return Condition(col, ">=", value)
 }
 
-// Ste generates a smaller than or equal to conditional sql clause
-func Ste(col ColumnElem, value interface{}) Conditional {
+// Lte generates a less than or equal to conditional sql clause
+func Lte(col ColumnElem, value interface{}) Conditional {
 	return Condition(col, "<=", value)
 }
 

--- a/conditional_test.go
+++ b/conditional_test.go
@@ -104,17 +104,17 @@ func TestConditionals(t *testing.T) {
 	assert.Equal(t, "\"score\" > $9", sql)
 	assert.Equal(t, []interface{}{1500}, bindings)
 
-	st := St(score, 1500)
+	lt := Lt(score, 1500)
 
-	sql, bindings = st.Build(sqlite)
+	sql, bindings = lt.Build(sqlite)
 	assert.Equal(t, "score < ?", sql)
 	assert.Equal(t, []interface{}{1500}, bindings)
 
-	sql, bindings = st.Build(mysql)
+	sql, bindings = lt.Build(mysql)
 	assert.Equal(t, "`score` < ?", sql)
 	assert.Equal(t, []interface{}{1500}, bindings)
 
-	sql, bindings = st.Build(postgres)
+	sql, bindings = lt.Build(postgres)
 	assert.Equal(t, "\"score\" < $10", sql)
 	assert.Equal(t, []interface{}{1500}, bindings)
 
@@ -132,17 +132,17 @@ func TestConditionals(t *testing.T) {
 	assert.Equal(t, "\"score\" >= $11", sql)
 	assert.Equal(t, []interface{}{1500}, bindings)
 
-	ste := Ste(score, 1500)
+	lte := Lte(score, 1500)
 
-	sql, bindings = ste.Build(sqlite)
+	sql, bindings = lte.Build(sqlite)
 	assert.Equal(t, "score <= ?", sql)
 	assert.Equal(t, []interface{}{1500}, bindings)
 
-	sql, bindings = ste.Build(mysql)
+	sql, bindings = lte.Build(mysql)
 	assert.Equal(t, "`score` <= ?", sql)
 	assert.Equal(t, []interface{}{1500}, bindings)
 
-	sql, bindings = ste.Build(postgres)
+	sql, bindings = lte.Build(postgres)
 	assert.Equal(t, "\"score\" <= $12", sql)
 	assert.Equal(t, []interface{}{1500}, bindings)
 

--- a/session_test.go
+++ b/session_test.go
@@ -95,8 +95,8 @@ func TestSessionWrappings(t *testing.T) {
 		Limit(0, 20).
 		Filter(sessions.C("user_id").Eq("9efbc9ab-7914-426c-8818-7d40b0427c8f")).
 		Filter(sessions.C("user_id").NotEq("9efbc9ac-7914-426c-8818-7d40b0427c8f")).
-		Filter(sessions.C("created_at").Ste("2016-06-10")).
-		Filter(sessions.C("created_at").St("2016-06-10")).
+		Filter(sessions.C("created_at").Lte("2016-06-10")).
+		Filter(sessions.C("created_at").Lt("2016-06-10")).
 		Filter(sessions.C("created_at").Gte("2016-06-09")).
 		Filter(sessions.C("created_at").Gt("2016-06-09")).
 		Statement()


### PR DESCRIPTION
The operator '<' is generally refered as "less than" and not "smaller
than", and the short name for it in most libraries is 'lt', not 'st'.