### PR TITLE
Change the foreign key API

### DIFF
--- a/constraint_test.go
+++ b/constraint_test.go
@@ -27,10 +27,10 @@ func TestConstraints(t *testing.T) {
 	assert.Equal(t, "PRIMARY KEY(`id`, `email`)", PrimaryKey("id", "email").String(mysql))
 	assert.Equal(t, "PRIMARY KEY(\"id\", \"email\")", PrimaryKey("id", "email").String(postgres))
 
-	assert.Contains(t, ForeignKey().Ref("user_id", "users", "id").String(sqlite), "FOREIGN KEY(user_id) REFERENCES users(id)")
-	assert.Contains(t, ForeignKey().Ref("user_id", "users", "id").String(mysql), "FOREIGN KEY(`user_id`) REFERENCES `users`(`id`)")
-	assert.Contains(t, ForeignKey().Ref("user_id", "users", "id").String(postgres), "FOREIGN KEY(\"user_id\") REFERENCES \"users\"(\"id\")")
-	assert.Contains(t, ForeignKey().Ref("user_id", "users", "id").Ref("user_email", "users", "email").String(sqlite), "FOREIGN KEY(user_id, user_email) REFERENCES users(id, email)")
+	assert.Contains(t, ForeignKey("user_id").References("users", "id").String(sqlite), "FOREIGN KEY(user_id) REFERENCES users(id)")
+	assert.Contains(t, ForeignKey("user_id").References("users", "id").String(mysql), "FOREIGN KEY(`user_id`) REFERENCES `users`(`id`)")
+	assert.Contains(t, ForeignKey("user_id").References("users", "id").String(postgres), "FOREIGN KEY(\"user_id\") REFERENCES \"users\"(\"id\")")
+	assert.Contains(t, ForeignKey("user_id", "user_email").References("users", "id", "email").String(sqlite), "FOREIGN KEY(user_id, user_email) REFERENCES users(id, email)")
 
 	assert.Equal(t, "CONSTRAINT u_id_email UNIQUE(id, email)", UniqueKey("id", "email").String(sqlite))
 	assert.Equal(t, "CONSTRAINT u_id_email UNIQUE(`id`, `email`)", UniqueKey("id", "email").String(mysql))

--- a/mapper.go
+++ b/mapper.go
@@ -196,7 +196,9 @@ func (m *MapperElem) ToTable(model interface{}) (TableElem, error) {
 					continue
 				}
 
-				constraintClauses = append(constraintClauses, ForeignKey().Ref(colName, fkp[0], fkp[1]))
+				fk := ForeignKeyConstraints{}
+				fk = fk.Ref(colName, fkp[0], fkp[1])
+				constraintClauses = append(constraintClauses, fk)
 			} else if strings.Contains(v, "index") {
 				if strings.Contains(f.Name(), "CompositeIndex") {
 					is := strings.Split(v, ":")

--- a/select_test.go
+++ b/select_test.go
@@ -37,7 +37,7 @@ func (suite *SelectTestSuite) SetupTest() {
 		Column("user_id", BigInt()),
 		Column("auth_token", Varchar().Size(36)).Unique().NotNull(),
 		PrimaryKey("id"),
-		ForeignKey().Ref("user_id", "users", "id"),
+		ForeignKey("user_id").References("users", "id"),
 	)
 }
 

--- a/session_test.go
+++ b/session_test.go
@@ -74,7 +74,7 @@ func TestSessionWrappings(t *testing.T) {
 		Column("user_id", Varchar().Size(36)),
 		Column("created_at", Timestamp()).NotNull(),
 		PrimaryKey("id"),
-		ForeignKey().Ref("user_id", "users", "id"),
+		ForeignKey("user_id").References("users", "id"),
 	)
 
 	qb.Metadata().AddTable(users)

--- a/table.go
+++ b/table.go
@@ -30,7 +30,14 @@ func Table(name string, clauses ...TableClause) TableElem {
 			table.PrimaryKeyConstraint = clause.(PrimaryKeyConstraint)
 			break
 		case ForeignKeyConstraints:
-			table.ForeignKeyConstraints = clause.(ForeignKeyConstraints)
+			table.ForeignKeyConstraints.FKeys = append(
+				table.ForeignKeyConstraints.FKeys,
+				clause.(ForeignKeyConstraints).FKeys...)
+		case ForeignKeyConstraint:
+			table.ForeignKeyConstraints.FKeys = append(
+				table.ForeignKeyConstraints.FKeys,
+				clause.(ForeignKeyConstraint),
+			)
 			break
 		case UniqueKeyConstraint:
 			table.UniqueKeyConstraint = clause.(UniqueKeyConstraint)
@@ -94,7 +101,7 @@ func (t TableElem) Create(dialect Dialect) string {
 		colClauses = append(colClauses, fmt.Sprintf("\t%s", t.PrimaryKeyConstraint.String(dialect)))
 	}
 
-	if len(t.ForeignKeyConstraints.Refs) > 0 {
+	if len(t.ForeignKeyConstraints.FKeys) > 0 {
 		colClauses = append(colClauses, t.ForeignKeyConstraints.String(dialect))
 	}
 

--- a/table_test.go
+++ b/table_test.go
@@ -32,10 +32,9 @@ func (suite *TableTestSuite) TestTablePrimaryForeignKey() {
 		Column("auth_token", Varchar().Size(40)),
 		Column("role_id", Varchar().Size(40)),
 		PrimaryKey("id"),
-		ForeignKey().
-			Ref("session_id", "sessions", "id").
-			Ref("auth_token", "sessions", "auth_token").
-			Ref("role_id", "roles", "id"),
+		ForeignKey("session_id", "auth_token").
+			References("sessions", "id", "auth_token"),
+		ForeignKey("role_id").References("roles", "id"),
 	)
 
 	ddl := usersTable.Create(NewDialect("mysql"))


### PR DESCRIPTION
The new api allows multiple foreign keys between two tables:

Table(...,
   ForeignKey("c1", "c2").References("other_table", "c1", "c2")
)

Fix #101