### PR TITLE
[tests] Capture logs

### DIFF
--- a/logger_test.go
+++ b/logger_test.go
@@ -16,7 +16,9 @@ func TestLogger(t *testing.T) {
 	metadata.AddTable(actors)
 	metadata.CreateAll(engine)
 	defer metadata.DropAll(engine)
-	engine.SetLogger(&DefaultLogger{LQuery | LBindings, log.New(TestingLogWriter{t}, "", log.LstdFlags)})
+	logCapture := &TestingLogWriter{t, nil}
+	defer logCapture.Flush()
+	engine.SetLogger(&DefaultLogger{LQuery | LBindings, log.New(logCapture, "", log.LstdFlags)})
 	engine.Logger().SetLogFlags(LQuery)
 
 	_, err = engine.Exec(actors.Insert().Values(map[string]interface{}{"id": 5}))

--- a/logger_test.go
+++ b/logger_test.go
@@ -3,7 +3,6 @@ package qb
 import (
 	"github.com/stretchr/testify/assert"
 	"log"
-	"os"
 	"testing"
 )
 
@@ -17,7 +16,7 @@ func TestLogger(t *testing.T) {
 	metadata.AddTable(actors)
 	metadata.CreateAll(engine)
 	defer metadata.DropAll(engine)
-	engine.SetLogger(&DefaultLogger{LQuery | LBindings, log.New(os.Stdout, "", log.LstdFlags)})
+	engine.SetLogger(&DefaultLogger{LQuery | LBindings, log.New(TestingLogWriter{t}, "", log.LstdFlags)})
 	engine.Logger().SetLogFlags(LQuery)
 
 	_, err = engine.Exec(actors.Insert().Values(map[string]interface{}{"id": 5}))

--- a/testutils_test.go
+++ b/testutils_test.go
@@ -1,6 +1,19 @@
 package qb
 
+import (
+	"testing"
+)
+
 func asSQL(clause Clause, dialect Dialect) (string, []interface{}) {
 	ctx := NewCompilerContext(dialect)
 	return clause.Accept(ctx), ctx.Binds
+}
+
+type TestingLogWriter struct {
+	t *testing.T
+}
+
+func (w TestingLogWriter) Write(p []byte) (n int, err error) {
+	w.t.Log(string(p))
+	return len(p), nil
 }

--- a/testutils_test.go
+++ b/testutils_test.go
@@ -1,6 +1,7 @@
 package qb
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -10,10 +11,15 @@ func asSQL(clause Clause, dialect Dialect) (string, []interface{}) {
 }
 
 type TestingLogWriter struct {
-	t *testing.T
+	t     *testing.T
+	lines []string
 }
 
-func (w TestingLogWriter) Write(p []byte) (n int, err error) {
-	w.t.Log(string(p))
+func (w *TestingLogWriter) Write(p []byte) (n int, err error) {
+	w.lines = append(w.lines, string(p))
 	return len(p), nil
+}
+
+func (w *TestingLogWriter) Flush() {
+	w.t.Log("Captured:\n" + strings.Join(w.lines, ""))
 }


### PR DESCRIPTION
Setup the engine logger so that output is captured by the test Log()
function.
This way, the logs will be printed only if a test fails.